### PR TITLE
QA: harden WebSocket boundaries and resource lifecycles

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -848,6 +848,15 @@ async def _handle_message(session: SessionBus, websocket: WebSocket, message: di
     if kind == "intent":
         topic = message.get("topic", "")
         intent = message.get("intent", "")
+        if not isinstance(topic, str) or not isinstance(intent, str):
+            await websocket.send_json(
+                {
+                    "kind": "error",
+                    "id": msg_id,
+                    "error": "malformed message: 'topic' and 'intent' must be strings",
+                }
+            )
+            return
         # An omitted args field means no positional arguments. Preserve an
         # explicitly supplied falsey value so dispatch_intent can reject it
         # as malformed instead of silently converting it to an empty list.

--- a/backend/app.py
+++ b/backend/app.py
@@ -131,6 +131,7 @@ DEV_WS_ORIGIN_ENV = "GRAPHLINK_DEV_WS_ORIGIN"
 # that cannot be verified without a real browser - deliberately scoped to
 # just the directive this finding is actually about.
 CONTENT_SECURITY_POLICY = "img-src 'self' data:"
+_WS_SEND_AFTER_CLOSE_ERROR = 'Cannot call "send" once a close message has been sent.'
 
 
 def _is_allowed_ws_origin(origin: str | None, host_header: str | None, dev_proxy_origin: str | None = None) -> bool:
@@ -705,13 +706,25 @@ def create_app(
                 # kind:error reply and the loop simply continues instead of
                 # tearing down the session.
                 try:
-                    message = await websocket.receive_json()
-                except json.JSONDecodeError:
-                    await websocket.send_json(
-                        {"kind": "error", "id": None, "error": "malformed message: invalid JSON"}
-                    )
-                    continue
-                await _handle_message(session, websocket, message)
+                    try:
+                        message = await websocket.receive_json()
+                    except json.JSONDecodeError:
+                        await websocket.send_json(
+                            {"kind": "error", "id": None, "error": "malformed message: invalid JSON"}
+                        )
+                        continue
+                    await _handle_message(session, websocket, message)
+                except RuntimeError as exc:
+                    # A client can close while an intent is still running;
+                    # Starlette then raises this exact error when the
+                    # handler tries to deliver its late result. That is a
+                    # normal disconnect race, not an application failure,
+                    # so end this socket cleanly while preserving unrelated
+                    # RuntimeErrors for the outer error machinery.
+                    if str(exc) != _WS_SEND_AFTER_CLOSE_ERROR:
+                        raise
+                    logger.debug("client disconnected while handling a websocket message")
+                    break
         except WebSocketDisconnect:
             pass
         finally:

--- a/backend/app.py
+++ b/backend/app.py
@@ -806,7 +806,10 @@ async def _handle_message(session: SessionBus, websocket: WebSocket, message: di
     msg_id = message.get("id")
 
     if kind == "subscribe":
-        topics = message.get("topics") or session.topic_names()
+        # Only an omitted topics field means "all topics". Preserve an
+        # explicitly supplied falsey value so the shape check below rejects
+        # it instead of broadening a malformed subscription request.
+        topics = message["topics"] if "topics" in message else session.topic_names()
         # REVIEW-FIX: same reasoning as the isinstance guard above, for the
         # one field this branch trusts without a shape check. A truthy
         # non-iterable "topics" (e.g. the JSON number 5) bypasses the `or`

--- a/backend/app.py
+++ b/backend/app.py
@@ -845,7 +845,10 @@ async def _handle_message(session: SessionBus, websocket: WebSocket, message: di
     if kind == "intent":
         topic = message.get("topic", "")
         intent = message.get("intent", "")
-        args = message.get("args") or []
+        # An omitted args field means no positional arguments. Preserve an
+        # explicitly supplied falsey value so dispatch_intent can reject it
+        # as malformed instead of silently converting it to an empty list.
+        args = message.get("args", [])
         try:
             result = await session.dispatch_intent(topic, intent, args)
         except UnknownTopicError as exc:

--- a/backend/events.py
+++ b/backend/events.py
@@ -173,7 +173,7 @@ def _validate_intent_args(args_schema: type, args: Any) -> list[str]:
     Review-fix: `args` is typed `list[Any]` by dispatch_intent's own
     signature, but that is a Python-side type hint, not a runtime guarantee -
     _handle_message (backend/app.py) builds it straight from
-    `message.get("args") or []` with no shape check, so a client sending a
+    `message.get("args", [])` with no shape check, so a client sending a
     JSON OBJECT for "args" reached here unchanged. zip(fields, a_dict) pairs
     each field with the dict's KEY strings (never its values), so validation
     could report zero errors while payload held only field-name echoes - and

--- a/backend/mcp_client.py
+++ b/backend/mcp_client.py
@@ -310,15 +310,23 @@ class McpStdioClient:
                 process.stdin.close()
         except Exception:
             pass
-        process.terminate()
         try:
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            process.kill()
+            process.terminate()
             try:
                 process.wait(timeout=5)
             except subprocess.TimeoutExpired:
-                pass
+                process.kill()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+        finally:
+            for thread in (self._reader_thread, self._stderr_thread):
+                if thread is not None and thread is not threading.current_thread():
+                    thread.join(timeout=1)
+            for stream in (process.stdin, process.stdout, process.stderr):
+                if stream is not None:
+                    stream.close()
 
     def list_tools(self) -> tuple[ToolSpec, ...]:
         response = self._call("tools/list", {})

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -967,15 +967,23 @@ class PluginWorkerClient:
                     process.stdin.close()
             except Exception:
                 pass
-            process.terminate()
             try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                process.kill()
+                process.terminate()
                 try:
                     process.wait(timeout=5)
                 except subprocess.TimeoutExpired:
-                    pass
+                    process.kill()
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        pass
+            finally:
+                for thread in (self._reader_thread, self._stderr_thread):
+                    if thread is not None and thread is not threading.current_thread():
+                        thread.join(timeout=1)
+                for stream in (process.stdin, process.stdout, process.stderr):
+                    if stream is not None:
+                        stream.close()
         # Exactly-once close, whether or not a process was ever spawned -
         # create_execution_guard()'s own close() is itself idempotent
         # (double-close-safe, see graphlink_execution_guard.py's own

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -642,6 +642,31 @@ def test_a_falsey_non_list_args_field_is_not_treated_as_omitted():
         assert snapshot["kind"] == "state"
 
 
+def test_non_string_intent_routing_fields_get_a_graceful_error():
+    """Routing fields are protocol strings, not arbitrary JSON values.
+
+    A dict/list currently reaches the tuple lookup in ``dispatch_intent`` and
+    raises ``TypeError`` before the intended validation response is built.
+    Reject both malformed fields at the WebSocket boundary and keep the
+    connection available for a valid request afterward.
+    """
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        for field, value, message_id in (("topic", {}, 3), ("intent", [], 4)):
+            frame = {"kind": "intent", "topic": "system", "intent": "ping", "args": [], "id": message_id}
+            frame[field] = value
+            ws.send_json(frame)
+            message = ws.receive_json()
+            assert message["kind"] == "error"
+            assert message["id"] == message_id
+            assert message["error"] == "malformed message: 'topic' and 'intent' must be strings"
+
+        ws.send_json({"kind": "intent", "topic": "system", "intent": "ping", "args": ["ok"], "id": 5})
+        message = ws.receive_json()
+        assert message["kind"] == "result"
+        assert message["value"]["echo"] == ["ok"]
+
+
 def test_sessions_do_not_share_connections():
     # ADR-004 stage 4.3: tests EventBus's own generic cross-session
     # isolation mechanism, a scenario the real shipped app's restrictive

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -561,6 +561,26 @@ def test_a_non_list_topics_field_gets_a_graceful_error_not_a_dropped_connection(
         assert snapshot["kind"] == "state"
 
 
+def test_a_falsey_non_list_topics_field_is_not_treated_as_omitted():
+    """Only an omitted ``topics`` field requests every registered topic.
+
+    Treating explicit JSON ``false`` as omission makes malformed input change
+    the subscription scope unexpectedly. It should receive the same graceful
+    shape error as a truthy scalar and leave the connection usable.
+    """
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"kind": "subscribe", "topics": False, "id": 2})
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        assert message["id"] == 2
+        assert message["error"] == "malformed message: 'topics' must be a list"
+
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        snapshot = ws.receive_json()
+        assert snapshot["kind"] == "state"
+
+
 def test_a_non_string_topic_element_gets_a_graceful_error_not_a_dropped_connection():
     """SECURITY-FIX: `topics` was checked to be a list, but not that each
     ELEMENT is a string - {"topics": [{}]} passed the list check and

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -9,7 +9,9 @@ import threading
 import time
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from backend import BACKEND_VERSION, crash_recovery
 from backend.app import create_app
@@ -193,6 +195,19 @@ def test_ping_round_trip_returns_echo_and_server_time():
         assert message["id"] == 1
         assert message["value"]["echo"] == ["hello"]
         assert message["value"]["serverTime"] > 0
+
+
+def test_a_late_result_after_client_close_is_treated_as_a_disconnect(monkeypatch):
+    async def send_after_close(session, websocket, message):
+        await websocket.close()
+        raise RuntimeError('Cannot call "send" once a close message has been sent.')
+
+    monkeypatch.setattr("backend.app._handle_message", send_after_close)
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"kind": "intent", "topic": "system", "intent": "ping", "args": []})
+        with pytest.raises(WebSocketDisconnect):
+            ws.receive_json()
 
 
 def test_unknown_intent_and_topic_return_error_not_disconnect():

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -600,6 +600,28 @@ def test_a_non_list_args_field_for_an_unschemad_intent_gets_a_graceful_error_not
         assert snapshot["kind"] == "state"
 
 
+def test_a_falsey_non_list_args_field_is_not_treated_as_omitted():
+    """The wire contract requires ``args`` to be an array when present.
+
+    ``message.get("args") or []`` made a falsey scalar such as JSON ``false``
+    indistinguishable from an omitted field, so ``system/ping`` returned a
+    successful empty call instead of the same validation error used for a
+    truthy scalar or object.  This must be rejected without closing the
+    connection.
+    """
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"kind": "intent", "topic": "system", "intent": "ping", "args": False, "id": 2})
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        assert message["id"] == 2
+        assert message["error"] == "Invalid arguments: expected a list of arguments, got bool."
+
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        snapshot = ws.receive_json()
+        assert snapshot["kind"] == "state"
+
+
 def test_sessions_do_not_share_connections():
     # ADR-004 stage 4.3: tests EventBus's own generic cross-session
     # isolation mechanism, a scenario the real shipped app's restrictive

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -2702,8 +2702,8 @@ class TestCorruptDbRescue:
             # the real busy_timeout - a fresh connect() with its own short
             # timeout is what actually raises "database is locked".
             with pytest.raises(sqlite3.OperationalError):
-                blocked = sqlite3.connect(db_path, timeout=0.2)
-                blocked.execute("BEGIN IMMEDIATE")
+                with contextlib.closing(sqlite3.connect(db_path, timeout=0.2)) as blocked:
+                    blocked.execute("BEGIN IMMEDIATE")
         finally:
             holder.rollback()
             holder.close()

--- a/backend/tests/test_code_sandbox_domain.py
+++ b/backend/tests/test_code_sandbox_domain.py
@@ -376,6 +376,18 @@ class TestStop:
         sandbox.stop()  # must not raise
         assert sandbox.current_process is None
 
+    def test_stop_closes_all_subprocess_streams(self):
+        sandbox = VirtualEnvSandbox("stop-closes-streams-test")
+        fake_process = MagicMock()
+        fake_process.poll.return_value = None
+        sandbox.current_process = fake_process
+
+        sandbox.stop()
+
+        fake_process.stdin.close.assert_called_once()
+        fake_process.stdout.close.assert_called_once()
+        fake_process.stderr.close.assert_called_once()
+
     def test_the_guard_is_closed_before_the_process_is_terminated(self):
         # Pins the ordering ADR-005 stage 5.2's own comment on stop()
         # requires: on Windows, closing the guard first is what actually

--- a/backend/tests/test_execution_guard.py
+++ b/backend/tests/test_execution_guard.py
@@ -101,6 +101,7 @@ class TestJobObjectMechanism:
             assert count < 200, f"active-process cap of 5 did not stop the fork bomb - {count} processes ran"
         finally:
             guard.close()
+            proc.wait(timeout=5)
 
     def test_closing_the_guard_kills_a_grandchild_process_too(self, tmp_path):
         marker = tmp_path / "marker.txt"
@@ -131,6 +132,7 @@ class TestJobObjectMechanism:
         assert marker.stat().st_size > size_before, "grandchild isn't actively writing before close()"
 
         guard.close()  # the actual mechanism PythonREPL.stop()/VirtualEnvSandbox.stop() use
+        proc.wait(timeout=5)
         time.sleep(1.5)
         size_after_close = marker.stat().st_size
         time.sleep(1.5)
@@ -382,10 +384,14 @@ class TestPythonReplRestartDoesNotLeakTheOldGuard:
             # memory cap) the OS terminating it for exceeding
             # JobMemoryLimit sometime after the previous execute() call
             # already returned.
-            repl.process.kill()
-            repl.process.wait()
+            old_process = repl.process
+            assert old_process is not None
+            old_process.kill()
+            old_process.wait()
 
             repl.execute("2 + 2")  # execute()'s poll()-based restart path
+            assert old_process.stdin is not None and old_process.stdin.closed
+            assert old_process.stdout is not None and old_process.stdout.closed
             assert len(guards_created) == 2
             assert first_guard.closed is True, (
                 "start() must close any pre-existing guard before "

--- a/backend/tests/test_knowledge_store.py
+++ b/backend/tests/test_knowledge_store.py
@@ -338,7 +338,10 @@ class TestCorruptDbRescue:
         try:
             with pytest.raises(sqlite3.OperationalError):
                 blocked = sqlite3.connect(db_path, timeout=0.2)
-                blocked.execute("BEGIN IMMEDIATE")
+                try:
+                    blocked.execute("BEGIN IMMEDIATE")
+                finally:
+                    blocked.close()
         finally:
             holder.rollback()
             holder.close()

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -184,8 +184,13 @@ def test_call_before_connect_raises_mcp_error(fake_fs_server):
 def test_close_is_idempotent(fake_fs_server):
     client = McpStdioClient(command=sys.executable, args=(fake_fs_server,))
     client.connect()
+    process = client._process
+    assert process is not None
     client.close()
     client.close()  # must not raise
+    assert process.stdin is not None and process.stdin.closed
+    assert process.stdout is not None and process.stdout.closed
+    assert process.stderr is not None and process.stderr.closed
 
 
 # -- register_mcp_server_tools: namespacing + enabled_tools filter ----------

--- a/backend/tests/test_plugin_worker.py
+++ b/backend/tests/test_plugin_worker.py
@@ -630,8 +630,13 @@ def test_worker_client_close_is_idempotent(tmp_path):
     )
     worker = PluginWorkerClient(plugin_id="oop_close_twice", source_dir=plugin_dir)
     worker.connect()
+    process = worker._process
+    assert process is not None
     worker.close()
     worker.close()  # must not raise
+    assert process.stdin is not None and process.stdin.closed
+    assert process.stdout is not None and process.stdout.closed
+    assert process.stderr is not None and process.stderr.closed
 
 
 # -- F: register_plugin_tools() flows plugin intents to the ToolRegistry ----

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -2780,8 +2780,11 @@ def test_rest_http_errors_preserve_status_and_retry_after(monkeypatch):
         raise http_error
 
     monkeypatch.setattr(api_provider.urllib.request, "urlopen", raising_urlopen)
-    with pytest.raises(RuntimeError, match="rate limited") as excinfo:
-        api_provider._anthropic_post_json("https://api.anthropic.com/v1/messages", {}, api_key="k")
-    assert excinfo.value.status_code == 429
-    assert excinfo.value.retry_after == 7.0
-    assert api_provider._is_transient_transport_error(excinfo.value) is True
+    try:
+        with pytest.raises(RuntimeError, match="rate limited") as excinfo:
+            api_provider._anthropic_post_json("https://api.anthropic.com/v1/messages", {}, api_key="k")
+        assert excinfo.value.status_code == 429
+        assert excinfo.value.retry_after == 7.0
+        assert api_provider._is_transient_transport_error(excinfo.value) is True
+    finally:
+        http_error.close()

--- a/backend/tests/test_python_repl.py
+++ b/backend/tests/test_python_repl.py
@@ -30,6 +30,19 @@ def test_state_persists_across_calls_and_reports_success():
         repl.stop()
 
 
+def test_stop_closes_the_subprocess_pipes_instead_of_leaving_them_to_gc():
+    repl = PythonREPL(repl_id="core-pipe-cleanup-test")
+    repl.execute("print('ready')")
+    process = repl.process
+    assert process is not None
+
+    repl.stop()
+
+    assert process.stdin is not None and process.stdin.closed
+    assert process.stdout is not None and process.stdout.closed
+    assert process.stderr is None
+
+
 def test_a_failed_execution_is_reported_without_killing_the_repl():
     repl = PythonREPL(repl_id="core-failure-test")
     try:

--- a/backend/tests/test_session_format_adr009.py
+++ b/backend/tests/test_session_format_adr009.py
@@ -279,7 +279,7 @@ def test_store_rejects_a_ref_that_is_not_a_content_digest(tmp_path):
     ref = store.put(b"real image bytes")
     assert store.get(ref) == b"real image bytes"
 
-    for crafted in ("../secret.txt", "../../secret.txt", "..\secret.txt", "", "x", ref.upper()):
+    for crafted in ("../secret.txt", "../../secret.txt", r"..\secret.txt", "", "x", ref.upper()):
         assert store.get(crafted) is None, crafted
         assert store.exists(crafted) is False, crafted
         assert store.verify(crafted) is False, crafted

--- a/graphlink_plugins/code_sandbox/domain.py
+++ b/graphlink_plugins/code_sandbox/domain.py
@@ -331,18 +331,25 @@ class VirtualEnvSandbox:
         # the guard already killed it, and the only thing that actually
         # stops the direct child on non-Windows in this stage (the POSIX
         # process-group tier is ADR-005 stage 5.3).
+        process = self.current_process
         if self.guard:
             self.guard.close()
             self.guard = None
-        if self.current_process and self.current_process.poll() is None:
+        if process is not None:
             try:
-                self.current_process.terminate()
-                self.current_process.wait(timeout=3)
-            except Exception:
-                try:
-                    self.current_process.kill()
-                except Exception:
-                    pass
+                if process.poll() is None:
+                    try:
+                        process.terminate()
+                        process.wait(timeout=3)
+                    except Exception:
+                        try:
+                            process.kill()
+                        except Exception:
+                            pass
+            finally:
+                for stream in (process.stdin, process.stdout, process.stderr):
+                    if stream is not None:
+                        stream.close()
         self.current_process = None
 
     def _run_subprocess(self, args, should_continue, emit_line=None, cwd=None, timeout_seconds=None):
@@ -454,6 +461,9 @@ class VirtualEnvSandbox:
             if self.guard:
                 self.guard.close()
                 self.guard = None
+            for stream in (process.stdin, process.stdout, process.stderr):
+                if stream is not None:
+                    stream.close()
             self.current_process = None
 
     def ensure_base_environment(self, should_continue, emit_line=None):

--- a/graphlink_plugins/common/python_repl.py
+++ b/graphlink_plugins/common/python_repl.py
@@ -239,6 +239,7 @@ while True:
         # nulling self.process out from under the other's later use of it).
         with self._lock:
             if self.process:
+                process = self.process
                 # ADR-005 stage 5.2: close the resource guard FIRST - on
                 # Windows this terminates the whole job (the REPL process
                 # AND anything it has itself spawned), closing the
@@ -252,9 +253,19 @@ while True:
                 if self.guard:
                     self.guard.close()
                     self.guard = None
-                self.process.kill()
-                self.process.wait()
-                self.process = None
+                try:
+                    process.kill()
+                    process.wait()
+                finally:
+                    # Popen owns real pipe objects for stdin/stdout even
+                    # after the child has been reaped. Close them here
+                    # rather than relying on Popen's finalizer, which
+                    # otherwise emits ResourceWarning and leaves cleanup
+                    # dependent on garbage collection.
+                    for stream in (process.stdin, process.stdout, process.stderr):
+                        if stream is not None:
+                            stream.close()
+                    self.process = None
 
 
 class CodeAnalysisAgent:

--- a/graphlink_plugins/common/python_repl.py
+++ b/graphlink_plugins/common/python_repl.py
@@ -123,6 +123,17 @@ class PythonREPL:
             if self.guard:
                 self.guard.close()
                 self.guard = None
+            old_process = self.process
+            self.process = None
+            if old_process is not None:
+                try:
+                    if old_process.poll() is None:
+                        old_process.kill()
+                        old_process.wait()
+                finally:
+                    for stream in (old_process.stdin, old_process.stdout, old_process.stderr):
+                        if stream is not None:
+                            stream.close()
             nonce = uuid.uuid4().hex
             self._boundary_prefix = f"---GRAPHLINK_EXEC_BOUNDARY:{nonce}:"
             script = f"""

--- a/graphlink_plugins/web_research/providers.py
+++ b/graphlink_plugins/web_research/providers.py
@@ -56,7 +56,13 @@ def dependency_status() -> dict[str, bool]:
 
 def source_id_for_url(url: str, rank: int = 0) -> str:
     canonical = canonicalize_url(url) or str(url or "")
-    digest = hashlib.sha1(canonical.encode("utf-8", errors="replace")).hexdigest()[:10]
+    # This is a compact deterministic identifier, never an authentication or
+    # integrity token. Marking that contract explicitly keeps the helper
+    # usable in runtimes that distinguish security-sensitive hashing (for
+    # example, FIPS-configured Python builds).
+    digest = hashlib.sha1(
+        canonical.encode("utf-8", errors="replace"), usedforsecurity=False
+    ).hexdigest()[:10]
     return f"s{rank + 1}-{digest}"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "graphlink"
 dynamic = ["version"]
 description = "A local-first, graph-based AI workspace for branching reasoning, tool use, and multi-provider workflows."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
     "anthropic",

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -3400,6 +3400,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "dev": true,

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -954,6 +954,17 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -3388,6 +3399,51 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
@@ -9160,13 +9216,14 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -21,7 +21,8 @@
   "overrides": {
     "eslint-plugin-jsx-a11y": {
       "eslint": "$eslint"
-    }
+    },
+    "qs": "6.15.3"
   },
   "dependencies": {
     "@xyflow/react": "^12.11.2",

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -2171,10 +2171,24 @@ export function computeSmartGuideFrame(
  * benefit. A node the backend actually removed is simply absent from
  * `rebuilt`, so a stale id can never resurrect one; a genuinely NEW node
  * has no prior state to carry and measures normally on first mount.
+ *
+ * POSITION (BUG FIX, found investigating a reported "node hasn't caught up"
+ * sputter after a fast drag+release): `pendingSettledIds` names nodes whose
+ * drag was JUST committed via store.moveNodes but whose backend echo has not
+ * landed in `scene` yet - see useNodeDragAndSizeSync's own doc on
+ * pendingSettledIdsRef for the exact race. Ordinarily `rebuilt`'s
+ * scene-derived position is trusted unconditionally (a remote client's own
+ * move must win), but for exactly these ids `current`'s (this drag's real,
+ * just-dropped) position is carried over instead, the same "prefer current
+ * over a still-stale rebuild" pattern as selection/measured above. The
+ * caller (CanvasInner's scene-sync effect) clears an id out of the set the
+ * next time `scene` itself actually changes - not here, since this function
+ * has no way to tell a stale rebuild from a fresh one.
  */
 export function withPreservedFlowState(
   rebuilt: SceneFlowNode[],
   current: SceneFlowNode[],
+  pendingSettledIds?: ReadonlySet<string>,
 ): SceneFlowNode[] {
   if (current.length === 0) return rebuilt;
   const currentById = new Map(current.map((n) => [n.id, n]));
@@ -2184,11 +2198,13 @@ export function withPreservedFlowState(
     if (!prev || prev === n) return n;
     const selected = prev.selected === true;
     const measured = n.measured === undefined ? prev.measured : undefined;
-    if (!selected && measured === undefined) return n;
+    const preservePosition = pendingSettledIds?.has(n.id) === true;
+    if (!selected && measured === undefined && !preservePosition) return n;
     changed = true;
     const clone: SceneFlowNode = { ...n };
     if (selected) clone.selected = true;
     if (measured !== undefined) clone.measured = measured;
+    if (preservePosition) clone.position = prev.position;
     return clone;
   });
   return changed ? merged : rebuilt;
@@ -2383,11 +2399,14 @@ function CanvasInner({
   // reporting back to the backend - one cohesive, already-interdependent
   // subsystem, and the most safety-critical piece of this canvas. See the
   // hook's own module doc for why it moved as a single unit.
-  const { nodesRef, draggingRef, dragActive, smartGuideLines, onNodesChange, onDelete } = useNodeDragAndSizeSync(
-    scene,
-    reactFlow,
-    store,
-  );
+  const { nodesRef, draggingRef, dragActive, smartGuideLines, onNodesChange, onDelete, pendingSettledIdsRef } =
+    useNodeDragAndSizeSync(scene, reactFlow, store);
+  // BUG FIX (node position reverting after a fast drag+release): the LAST
+  // `scene` reference the sync effect below actually reconciled against -
+  // see that effect's own doc for why this, not pendingSettledIdsRef.current
+  // being non-empty, is what decides whether a settled drag's ids are still
+  // owed a real echo.
+  const lastSyncedSceneRef = useRef<SceneState | null>(null);
   const visibleGuideLines = scene.smartGuides ? smartGuideLines : [];
 
   // R8a (UI/UX issue list finding #11): the View popover's FONT section
@@ -2425,6 +2444,10 @@ function CanvasInner({
         filterStatuses,
       ),
       nodesRef.current,
+      // BUG FIX: see withPreservedFlowState's own POSITION doc and
+      // pendingSettledIdsRef's doc (useNodeDragAndSizeSync.ts) for the full
+      // race this closes. Read, never mutated, here.
+      pendingSettledIdsRef.current,
     );
     // Mirror advances with the state it describes - see nodesRef's comment.
     nodesRef.current = next;
@@ -2432,15 +2455,32 @@ function CanvasInner({
     // this is the same setter React Flow's internal prop-sync would call, so
     // the renderer is updated in this effect instead of one commit later.
     storeApi.getState().setNodes(next);
+    // BUG FIX: only a genuinely NEW `scene` reference means "the backend has
+    // moved past where it was when this drag settled" - this effect can also
+    // re-run with the SAME `scene` (e.g. `dragActive` flipping false is
+    // itself a dependency below, precisely so a mid-drag publish isn't lost -
+    // see the REVIEW-FIX comment just below), and clearing on every run
+    // would drop the position pin on that very re-run, before any echo could
+    // possibly have arrived. Once `scene` does change, every id pinned above
+    // has been applied to this render's own merge already, so it's safe to
+    // stop pinning them from here on - the ordinary case is that a `scene`
+    // change immediately after a settle IS that drag's own echo; the same
+    // per-session ordering that makes moveNodes' "last write wins" claim true
+    // (backend/run_lifecycle's single-actor-per-session processing) means any
+    // publish arriving after it was sent already reflects it, mid-drag
+    // publish or not.
+    if (scene !== lastSyncedSceneRef.current) pendingSettledIdsRef.current.clear();
+    lastSyncedSceneRef.current = scene;
   }, [
     scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus, focusAcceptedPaths,
     getComposerRoute, filterKinds, filterStatuses,
-    // nodesRef/draggingRef/storeApi are all stable ref/store-api identities
-    // (useNodeDragAndSizeSync's/useStoreApi's own refs never change across
-    // renders) - listed here only because they now cross a hook boundary,
-    // which stops react-hooks/exhaustive-deps from inferring that stability
-    // on its own; behaviorally a no-op, same as before this extraction.
-    nodesRef, draggingRef, storeApi,
+    // nodesRef/draggingRef/storeApi/pendingSettledIdsRef/lastSyncedSceneRef
+    // are all stable ref/store-api identities (useNodeDragAndSizeSync's/
+    // useStoreApi's own refs never change across renders) - listed here only
+    // because they now cross a hook boundary, which stops react-hooks/
+    // exhaustive-deps from inferring that stability on its own; behaviorally
+    // a no-op, same as before this extraction.
+    nodesRef, draggingRef, storeApi, pendingSettledIdsRef, lastSyncedSceneRef,
     // REVIEW-FIX: a scene publish that lands while draggingRef.current is
     // true bails out of this effect ABOVE and is discarded entirely, not
     // queued - and draggingRef is a plain ref, so nothing here re-ran when

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -2407,6 +2407,12 @@ function CanvasInner({
   // being non-empty, is what decides whether a settled drag's ids are still
   // owed a real echo.
   const lastSyncedSceneRef = useRef<SceneState | null>(null);
+  // A scene publish that arrives while dragging is deliberately skipped by
+  // the sync effect and must still be reconciled when the gesture ends. Keep
+  // its identity separate from lastSyncedSceneRef so a genuinely NEW scene
+  // arriving after the drop cannot be mistaken for that skipped snapshot and
+  // have a stale local-position pin applied to it.
+  const skippedSceneWhileDraggingRef = useRef<SceneState | null>(null);
   const visibleGuideLines = scene.smartGuides ? smartGuideLines : [];
 
   // R8a (UI/UX issue list finding #11): the View popover's FONT section
@@ -2425,7 +2431,12 @@ function CanvasInner({
   const { onMove, viewportTimerRef } = useViewportReporting(store);
 
   useEffect(() => {
-    if (draggingRef.current) return;
+    if (draggingRef.current) {
+      skippedSceneWhileDraggingRef.current = scene;
+      return;
+    }
+    const preservePendingSettles =
+      scene === lastSyncedSceneRef.current || scene === skippedSceneWhileDraggingRef.current;
     const next = withPreservedFlowState(
       toFlowNodes(
         scene,
@@ -2447,7 +2458,7 @@ function CanvasInner({
       // BUG FIX: see withPreservedFlowState's own POSITION doc and
       // pendingSettledIdsRef's doc (useNodeDragAndSizeSync.ts) for the full
       // race this closes. Read, never mutated, here.
-      pendingSettledIdsRef.current,
+      preservePendingSettles ? pendingSettledIdsRef.current : undefined,
     );
     // Mirror advances with the state it describes - see nodesRef's comment.
     nodesRef.current = next;
@@ -2455,21 +2466,13 @@ function CanvasInner({
     // this is the same setter React Flow's internal prop-sync would call, so
     // the renderer is updated in this effect instead of one commit later.
     storeApi.getState().setNodes(next);
-    // BUG FIX: only a genuinely NEW `scene` reference means "the backend has
-    // moved past where it was when this drag settled" - this effect can also
-    // re-run with the SAME `scene` (e.g. `dragActive` flipping false is
-    // itself a dependency below, precisely so a mid-drag publish isn't lost -
-    // see the REVIEW-FIX comment just below), and clearing on every run
-    // would drop the position pin on that very re-run, before any echo could
-    // possibly have arrived. Once `scene` does change, every id pinned above
-    // has been applied to this render's own merge already, so it's safe to
-    // stop pinning them from here on - the ordinary case is that a `scene`
-    // change immediately after a settle IS that drag's own echo; the same
-    // per-session ordering that makes moveNodes' "last write wins" claim true
-    // (backend/run_lifecycle's single-actor-per-session processing) means any
-    // publish arriving after it was sent already reflects it, mid-drag
-    // publish or not.
+    // BUG FIX: only a scene that was already reconciled or was skipped during
+    // the active drag may use the local-position pin. A different scene is a
+    // fresh post-drop update (including a remote writer's move), so it must be
+    // trusted before the pin is cleared. This ordering matters when that
+    // remote update is the first scene frame observed after release.
     if (scene !== lastSyncedSceneRef.current) pendingSettledIdsRef.current.clear();
+    skippedSceneWhileDraggingRef.current = null;
     lastSyncedSceneRef.current = scene;
   }, [
     scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus, focusAcceptedPaths,
@@ -2481,6 +2484,7 @@ function CanvasInner({
     // exhaustive-deps from inferring that stability on its own; behaviorally
     // a no-op, same as before this extraction.
     nodesRef, draggingRef, storeApi, pendingSettledIdsRef, lastSyncedSceneRef,
+    skippedSceneWhileDraggingRef,
     // REVIEW-FIX: a scene publish that lands while draggingRef.current is
     // true bails out of this effect ABOVE and is discarded entirely, not
     // queued - and draggingRef is a plain ref, so nothing here re-ran when

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -416,6 +416,51 @@ describe("SceneCanvas <ReactFlow> wiring (ADR-011 stages 11.2/11.3)", () => {
         "b",
         "c",
       ]);
+      const settledA = capturedStoreApiRef
+        .current!.getState()
+        .nodes.find((n: { id: string }) => n.id === "a") as { position: { x: number; y: number } };
+      expect(settledA.position).toEqual({ x: 10, y: 0 });
+    });
+
+    // BUG FIX: found investigating a reported "node hasn't caught up" sputter
+    // on a fast drag+release - see withPreservedFlowState's own POSITION doc
+    // and pendingSettledIdsRef's doc (useNodeDragAndSizeSync.ts) for the
+    // mechanism. This is the plain case with no mid-drag publish at all: the
+    // scene-sync effect above still re-runs the instant `dragActive` flips
+    // false (that is the whole point of the REVIEW-FIX round 3 fix just
+    // above), and store.moveNodes is fire-and-forget - `scene` has not
+    // caught up to the drop yet, so without the pin this rebuilds "a" straight
+    // from the still-pre-drag scene and snaps it back to x=0.
+    it("keeps the dropped node at its real position instead of snapping back to the stale pre-drag scene", () => {
+      const { stateListeners } = mount();
+      publish(stateListeners, { nodes: [chatRow("a", 0), chatRow("b", 200)], edges: [] });
+
+      const drag = (change: Partial<NodeChange> & { id: string }) =>
+        act(() => {
+          const raw = [{ type: "position", ...change } as NodeChange];
+          lastProps().onNodesChange(capturedMiddleware ? capturedMiddleware(raw) : raw);
+        });
+
+      drag({ id: "a", dragging: true, position: { x: 50, y: 0 } });
+      drag({ id: "a", dragging: true, position: { x: 300, y: 0 } });
+      drag({ id: "a", dragging: false, position: { x: 300, y: 0 } });
+
+      const settledA = capturedStoreApiRef
+        .current!.getState()
+        .nodes.find((n: { id: string }) => n.id === "a") as { position: { x: number; y: number } };
+      expect(settledA.position).toEqual({ x: 300, y: 0 });
+
+      // The pin must not be permanent: once the backend's real echo for this
+      // move actually arrives (a genuinely new `scene`), ordinary
+      // reconciliation must resume trusting it - including for a LATER,
+      // unrelated remote move of the same node, which must not get stuck
+      // pinned to this drag's now-stale value forever.
+      publish(stateListeners, { nodes: [chatRow("a", 300), chatRow("b", 200)], edges: [] });
+      publish(stateListeners, { nodes: [chatRow("a", 999), chatRow("b", 200)], edges: [] });
+      const remoteMovedA = capturedStoreApiRef
+        .current!.getState()
+        .nodes.find((n: { id: string }) => n.id === "a") as { position: { x: number; y: number } };
+      expect(remoteMovedA.position).toEqual({ x: 999, y: 0 });
     });
   });
 

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -462,6 +462,30 @@ describe("SceneCanvas <ReactFlow> wiring (ADR-011 stages 11.2/11.3)", () => {
         .nodes.find((n: { id: string }) => n.id === "a") as { position: { x: number; y: number } };
       expect(remoteMovedA.position).toEqual({ x: 999, y: 0 });
     });
+
+    it("lets a remote position win when it is the first scene update after the drop", () => {
+      const { stateListeners } = mount();
+      publish(stateListeners, { nodes: [chatRow("a", 0), chatRow("b", 200)], edges: [] });
+
+      const drag = (change: Partial<NodeChange> & { id: string }) =>
+        act(() => {
+          const raw = [{ type: "position", ...change } as NodeChange];
+          lastProps().onNodesChange(capturedMiddleware ? capturedMiddleware(raw) : raw);
+        });
+
+      drag({ id: "a", dragging: true, position: { x: 300, y: 0 } });
+      drag({ id: "a", dragging: false, position: { x: 300, y: 0 } });
+
+      // A remote writer can be the first scene update observed after the
+      // local intent. It is already authoritative and must not be hidden by
+      // the local stale-scene pin.
+      publish(stateListeners, { nodes: [chatRow("a", 999), chatRow("b", 200)], edges: [] });
+
+      const remoteMovedA = capturedStoreApiRef
+        .current!.getState().nodes
+        .find((n: { id: string }) => n.id === "a") as { position: { x: number; y: number } };
+      expect(remoteMovedA.position).toEqual({ x: 999, y: 0 });
+    });
   });
 
   // REVIEW-FIX (round 3): a frame/container member that is off-viewport

--- a/web_ui/src/app/canvas/useNodeDragAndSizeSync.ts
+++ b/web_ui/src/app/canvas/useNodeDragAndSizeSync.ts
@@ -63,6 +63,12 @@ export function useNodeDragAndSizeSync(
   smartGuideLines: GuideLine[];
   onNodesChange: (changes: NodeChange<SceneFlowNode>[]) => void;
   onDelete: (payload: { nodes: Node[]; edges: Edge[] }) => void;
+  // BUG FIX (node position reverting after a fast drag+release): ids just
+  // committed via store.moveNodes below, whose real position CanvasInner's
+  // scene-sync effect must keep trusting from `nodesRef` rather than from
+  // `scene` - see that effect's own doc for why `scene` is stale at exactly
+  // this moment and what clears an id back out of this set.
+  pendingSettledIdsRef: MutableRefObject<Set<string>>;
 } {
   // Local node state exists so dragging is fluid; backend snapshots are the
   // truth and reconcile in whenever nothing is being dragged. dragStartRef
@@ -88,6 +94,19 @@ export function useNodeDragAndSizeSync(
   // plain ref (not state) since a rebuild must never itself trigger a
   // re-render - it only matters to onNodesChange's own closure.
   const dragSizeCacheRef = useRef<Map<string, { width: number; height: number }>>(new Map());
+  // BUG FIX (node position reverting after a fast drag+release): store
+  // .moveNodes below is fire-and-forget (SceneStore.moveNodes just calls
+  // transport.fireIntent, no local optimistic scene update) - the backend
+  // echo carrying the new position back into `scene` has not landed yet by
+  // the time this drag's own settle runs. CanvasInner's scene-sync effect
+  // reconciles the instant `dragActive` flips false (see that effect's own
+  // dependency-array comment, added in #REVIEW-FIX round 3 to stop losing an
+  // UNRELATED mid-drag scene update) - which, without this set, rebuilds
+  // straight from that still-stale `scene` and snaps the just-dropped node
+  // back to where it started, only to jump forward again once the real echo
+  // arrives moments later. See withPreservedFlowState's own doc for the read
+  // side of this ref.
+  const pendingSettledIdsRef = useRef<Set<string>>(new Set());
 
   // R7.5b-3: the smart-guide lines currently visible during a drag - local
   // component state only, never scene state, matching legacy's non-persisted
@@ -392,7 +411,12 @@ export function useNodeDragAndSizeSync(
       // being briefly stale - a real glitch on every group drag, not a
       // cosmetic footnote. moveNodes commits every position in one pass
       // server-side and publishes exactly once.
-      if (settledMoveIntents.length > 0) store.moveNodes(settledMoveIntents);
+      if (settledMoveIntents.length > 0) {
+        store.moveNodes(settledMoveIntents);
+        // See pendingSettledIdsRef's own doc above - cleared once a genuinely
+        // fresh scene arrives (CanvasInner's scene-sync effect), not here.
+        for (const intent of settledMoveIntents) pendingSettledIdsRef.current.add(intent.id);
+      }
       // Guides re-derive every drag frame (legacy cleared + re-added its
       // QGraphicsLineItems per recompute); drag end always clears. The
       // values come from the middleware's own most recent frame.
@@ -448,5 +472,5 @@ export function useNodeDragAndSizeSync(
     [store],
   );
 
-  return { nodesRef, draggingRef, dragActive, smartGuideLines, onNodesChange, onDelete };
+  return { nodesRef, draggingRef, dragActive, smartGuideLines, onNodesChange, onDelete, pendingSettledIdsRef };
 }

--- a/web_ui/src/app/canvas/useNodeDragAndSizeSync.ts
+++ b/web_ui/src/app/canvas/useNodeDragAndSizeSync.ts
@@ -42,12 +42,10 @@ import {
  * that effect keeps reading/mutating the exact same ref identities.
  *
  * `scene` is threaded through (rather than destructuring just
- * `smartGuides`/`dragFactor`) to keep the middleware's own dependency
- * array reading `scene.dragFactor`/`scene.smartGuides` unchanged - see
- * that callback's own comment for why `scene.dragFactor` is listed there
- * even though the drag-speed factor no longer touches node motion at all
- * (it now scales canvas panning instead, in useCanvasPan.ts); this is
- * pre-existing behavior being relocated, not something to "fix" here.
+ * `smartGuides`) so the middleware can read the current guide setting in its
+ * event-time callback. The drag-speed factor no longer affects node motion;
+ * it scales canvas panning instead (useCanvasPan.ts), so it is intentionally
+ * absent from the middleware's dependency list.
  */
 export function useNodeDragAndSizeSync(
   scene: SceneState,
@@ -312,7 +310,7 @@ export function useNodeDragAndSizeSync(
       // so React Flow commits the group and its members together.
       return memberChanges.length > 0 ? [...corrected, ...memberChanges] : corrected;
     },
-    [scene.dragFactor, scene.smartGuides, reactFlow],
+    [scene.smartGuides, reactFlow],
   );
 
   // Registers the correction above inside React Flow's own change pipeline.

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -111,6 +111,21 @@ describe("WsTransport", () => {
     expect(b).toHaveLength(0);
   });
 
+  it("drops a JSON null server frame without taking the transport down", () => {
+    const t = makeTransport();
+    const seen: unknown[] = [];
+    t.subscribe("system", (payload) => seen.push(payload));
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+
+    expect(() => socket.receive(null)).not.toThrow();
+
+    const payload = { schemaVersion: READER_SCHEMA_VERSION, app: "graphlink" };
+    socket.receive({ kind: "state", topic: "system", payload });
+    expect(seen).toEqual([payload]);
+  });
+
   it("replays the last compatible full snapshot to a late topic subscriber without another wire subscribe", () => {
     const t = makeTransport();
     const first: unknown[] = [];

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -968,13 +968,24 @@ export class WsTransport {
   }
 
   private handleMessage(raw: string): void {
-    let message: Record<string, unknown>;
+    let parsed: unknown;
     try {
-      message = JSON.parse(raw);
+      parsed = JSON.parse(raw);
     } catch {
       console.error("[ws] non-JSON frame dropped");
       return;
     }
+    // JSON.parse accepts valid scalar values and arrays as top-level JSON,
+    // but every server frame in this protocol is an object. In particular,
+    // reading `.kind` from a parsed `null` would throw out of the WebSocket
+    // event handler and can strand the transport in a broken connection
+    // state. Treat all non-object frames like malformed JSON: log and drop
+    // them while leaving the socket and pending requests untouched.
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      console.error("[ws] non-object frame dropped");
+      return;
+    }
+    const message = parsed as Record<string, unknown>;
     const kind = message.kind;
     if (kind === "state") {
       const topic = message.topic as string;


### PR DESCRIPTION
## Summary

This is a post-merge repository QA pass for the branch used by [#368](https://github.com/dovvnloading/Graphlink/pull/368). It closes independently reproduced defects at the WebSocket boundary, in drag/scene reconciliation, and in subprocess/resource lifecycles, while also clearing the dependency and static-analysis findings that stood up to review.

The scope is deliberately conservative: valid protocol behavior is unchanged, no database schema or migration is involved, and no user data format is changed.

## Verified findings and repairs

| Area | What was reproduced | Repair |
| --- | --- | --- |
| WebSocket command validation | Explicitly falsey `args` and `topics` values were silently normalized into valid-looking requests. Non-string routing fields could also reach dictionary/tuple lookups and raise instead of returning a protocol error. | Preserve explicitly supplied values, validate `topic`/`intent` types, reject malformed subscriptions, and return structured error frames while keeping the connection usable. |
| WebSocket frame handling | Valid JSON scalars, arrays, and `null` reached the backend handler without an object-shape guard; the browser transport could then dereference `.kind` on `null` and throw from the message event path. | Add the backend object guard and browser-side `unknown` parsing. Invalid JSON and non-object frames are logged/dropped or answered with the existing error envelope rather than taking down the session. |
| Disconnect race | Browser teardown during an in-flight intent produced Starlette's `Cannot call "send" once a close message has been sent.` traceback when the late result raced the close frame. | Recognize that exact framework-level disconnect race, log it at debug level, and end the socket cleanly while re-raising unrelated `RuntimeError` values. |
| Drag reconciliation | A fast drag/release could commit the local position, immediately reconcile against the still-old scene snapshot, and visibly snap the node back until the backend echo arrived. A first post-drop remote scene could also be incorrectly treated as the stale local snapshot. | Track just-settled ids and the scene snapshots skipped during an active drag. Preserve the local position only while the scene is known to be stale or intentionally deferred; trust a genuinely new scene, including a remote move, before clearing the pin. |
| Managed subprocesses | MCP, plugin-worker, sandbox, and Python REPL subprocess pipes were left to `Popen` finalization in normal shutdown/restart paths. The REPL restart path could also replace a dead process/guard without closing the old resources. | Close owned stdin/stdout/stderr streams deterministically, join reader threads where applicable, and clean up dead REPL processes and guards before replacement. |
| Test-owned resources | Focused tests left intentionally blocked SQLite connections, a synthetic `HTTPError` file, and direct guard child processes for garbage collection/reaping. | Make the test fixtures and cleanup paths explicit so warning-enabled runs exercise the same lifecycle contract they assert. |
| Dependency and static hygiene | `npm audit` reported two moderate `qs` advisories; the project metadata used deprecated license-table syntax; a test contained an invalid escape; Bandit flagged a deterministic non-security SHA-1 identifier. | Pin transitive `qs` to `6.15.3`, use SPDX `MIT` metadata, correct the test literal, and mark the compact URL identifier `usedforsecurity=False`. |
| Cross-platform npm installation | The first GitHub CI run on this PR exposed a platform-specific lockfile omission that Windows did not reproduce: Linux `npm ci` could not find bundled `@emnapi/core@1.11.3` and `@emnapi/runtime@1.11.3` records and stopped before frontend or E2E checks. | Record the bundled `@emnapi` package entries in the lockfile. Both normal and simulated-Linux `npm ci --ignore-scripts` now complete successfully; the fresh GitHub run is the final confirmation. |

## Validation

The following local gates passed against the final source tree:

- `python -m compileall -q .`
- `python -m ruff check .`
- `python -m mypy` — success across the configured 18 source files.
- `python -m pytest -q --cov --cov-report=term-missing --ignore=backend/tests/perf` — **3,072 passed, 19 skipped**, 88.47% coverage.
- `python -m pytest -q -n0 backend/tests/perf` — **8 passed**.
- Focused warning-enabled lifecycle suites for SQLite, REPL, MCP, plugin workers, sandbox execution, and provider HTTP errors — passed without repository-owned `ResourceWarning` output.
- `npm ci --ignore-scripts` — passed on Windows.
- `npm ci --ignore-scripts --os=linux --cpu=x64` — passed as the local Linux dependency-resolution simulation.
- `npm run check` — schema artifacts current, typecheck passed, Vitest **2,036 passed**, build passed, and bundle budgets passed. ESLint reported 0 errors; the 48 Fast Refresh warnings are pre-existing component/export warnings.
- `npm run test:e2e` — **5 passed**; the prior disconnect traceback no longer appears during browser teardown.
- `python -m pip_audit -r requirements.txt` — no known Python vulnerabilities.
- `npm audit --audit-level=moderate` — **0 vulnerabilities**.
- Bandit review at high-severity threshold — only the two intentional `shell=True` call sites in the user-approved shell execution tools remain; they were reviewed and are not changed by this PR.
- `python -m build --wheel` and `python -m twine check` — passed. A separate build from a clean Git archive produced a 178-entry wheel with no `__pycache__`, `.pyc`, or `.pyo` entries; the bytecode seen during the first local inspection was test-run residue, not a distribution artifact.
- `git diff --check` — passed.

The standard Python run still reports six upstream Starlette/httpx deprecation warnings from FastAPI's test client. They are outside this change and do not indicate an application failure.

## Commit and branch history

The work was kept traceable in focused commits:

- `e53d987` — Harden websocket input and drag reconciliation
- `ba594c0` — Clean up audit warnings and dev dependency
- `ddb99ee` — Close the intentionally blocked SQLite test connection
- `21c9225` — Reject falsey malformed topic subscriptions
- `428e33c` — Validate websocket intent routing fields
- `ebf611e` — Mark source identifiers as non-security hashes
- `a43c809` — Close the intentionally blocked knowledge-store test connection
- `fc67cfc` — Close Python REPL pipes during shutdown
- `936a844` — Close managed subprocess resources deterministically
- `d2c1460` — Handle websocket disconnect races cleanly
- `005cbbb` — Merge current `main` into the QA branch without rewriting history
- `057c0b7` — Repair the cross-platform npm lockfile

The pre-existing `e4b4f15` commit is the branch commit corresponding to the already-merged #368 change. Because `main` was squash-merged, the branch was synchronized with current `main` through a normal merge commit before this PR was opened; the review diff contains only the follow-up QA repairs. No force-push or new branch was used.

## Reviewer notes

The highest-risk behavior changes are intentionally narrow:

1. malformed WebSocket frames now receive a predictable error/drop treatment rather than being coerced or crashing the handler;
2. fresh scene publications are authoritative once they are distinguishable from the stale snapshot involved in a local drag;
3. cleanup closes resources owned by the component after the child has been stopped/reaped, without changing process guard semantics; and
4. the dependency changes are a patched transitive `qs` pin plus the platform-complete lockfile records required by clean CI installs.

There are no schema, migration, or rollout steps required.