### PR TITLE
Fix six defects in the workspace-agent (harness) subsystem

### DIFF
--- a/backend/api/intents_harness.py
+++ b/backend/api/intents_harness.py
@@ -124,6 +124,10 @@ def register_harness_intents(
             # cannot land mid-write against a concurrent settings save.
             await asyncio.to_thread(run_locked, lambda: settings.add_harness_trusted_dir(resolved))
         node.state.harness_workspace_path = resolved
+        # The previous run's bound root says nothing about THIS binding -
+        # left in place it reads as "the grant did not apply", which is
+        # exactly the warning the card shows for a refused folder.
+        node.state.harness_workspace_active = ""
         await publish_scene()
 
     async def use_scratch(node_id):
@@ -134,6 +138,7 @@ def register_harness_intents(
         if node is None or not isinstance(node.state, HarnessState):
             return
         node.state.harness_workspace_path = ""
+        node.state.harness_workspace_active = ""
         await publish_scene()
 
     async def approve_tool(request_id):

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -852,9 +852,13 @@ class HarnessState(NodeState):
     # is honored at run time only if it is in the settings trust list (see
     # backend/harness/workspace.bound_root); otherwise the run silently
     # uses scratch. harness_workspace_active is the RESULT the last run
-    # actually bound - the resolved user dir when the trust check passed,
-    # else "" - so the UI can show "working in <dir>" vs "scratch" honestly
-    # rather than echoing the unverified request.
+    # actually bound - the resolved root itself, whether that is the
+    # requested user dir or the scratch dir it fell back to - so the UI can
+    # tell "the grant did not apply here" apart from "no run has bound this
+    # node yet", which is the ONLY reading of a "" active. Rebinding the
+    # node (pick a folder / use scratch) clears it back to "" for exactly
+    # that reason: a stale result must never be read as a verdict on a
+    # binding it predates.
     harness_workspace_path: str = ""
     harness_workspace_active: str = ""
     harness_activity: list[dict[str, Any]] = field(default_factory=list)

--- a/backend/harness/loop.py
+++ b/backend/harness/loop.py
@@ -421,7 +421,10 @@ async def run_harness(
             settings_manager=settings_manager,
         )
         ctx.harness_workspace_dir = root
-        node.state.harness_workspace_active = str(root) if is_user_dir else ""
+        # The root this run ACTUALLY bound, scratch included: a "" here
+        # means "no run yet", which is what lets the card distinguish a
+        # refused grant from a binding that has simply not run.
+        node.state.harness_workspace_active = str(root)
 
         # §3.3: the session profile is locked to the root its history was
         # recorded against. Checked BEFORE anything is appended or any model
@@ -445,13 +448,18 @@ async def run_harness(
         # backend/harness/context.py's own docstring).
         system_prompt = context_module.build_system_prompt(root)
         user_message = {"role": "user", "content": user_text}
-        # profile/root stamp the meta line when this is the file's very
-        # first write; ignored on every later append.
-        append_message(transcript_dir, user_message, profile=profile, root=root)
+        # Load the PRIOR history BEFORE appending this task's own message.
+        # load_messages crosses the flush barrier itself, so appending
+        # first means the new message is already on disk when the load
+        # runs and it enters `history` twice - the model would see the
+        # request duplicated on every turn of every task.
         # `history` deliberately excludes the system prompt: it lives
         # outside history so compaction structurally cannot touch it (and
         # so the cacheable prefix is the same object every turn).
         history: list = [*load_messages(transcript_dir), user_message]
+        # profile/root stamp the meta line when this is the file's very
+        # first write; ignored on every later append.
+        append_message(transcript_dir, user_message, profile=profile, root=root)
 
         turns = 0
         max_turns = max(1, int(node.state.harness_max_turns))

--- a/backend/harness/shell_policy.py
+++ b/backend/harness/shell_policy.py
@@ -37,8 +37,15 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
-# Top-level separators, longest-first so `&&` is never read as two `&`.
-_SEPARATOR_RE = re.compile(r"(\|\||&&|;|\||\n)")
+# Top-level separators, longest-first so `&&` is never read as two `&`
+# and `||` is never read as two `|`. The bare `&` is in the list because
+# it chains on BOTH shells this app spawns: it is cmd.exe's ordinary
+# sequential separator (`build & rm -rf out`) and POSIX sh's background
+# operator, so a command after it runs either way - and a separator this
+# module does not know about is a segment whose contents are never
+# disclosed and never dangerous-checked, which is exactly the "dangerous
+# tail hiding behind a benign head" this module exists to prevent.
+_SEPARATOR_RE = re.compile(r"(\|\||&&|;|\||&|\n)")
 
 # Constructs whose contents we decline to parse - see the module docstring.
 _UNSPLITTABLE_MARKERS = ("$(", "`", "<(", ">(")

--- a/backend/harness/subagents.py
+++ b/backend/harness/subagents.py
@@ -126,15 +126,26 @@ async def run_subagent(
         {"role": "user", "content": task},
     ]
 
+    # The watchdog the parent loop puts around its own model call, applied
+    # here too. Without it a provider that accepts the connection and then
+    # never answers hangs the PARENT run forever: the parent is blocked
+    # inside registry.invoke, so its own wait_for is not covering anything,
+    # and Stop is the only way out. Imported late off backend.agents so a
+    # test that shrinks the constant is honored.
+    from backend import agents as _agents
+
     last_text = ""
     for _turn in range(max(1, max_turns)):
         if cancel_event is not None and cancel_event.is_set():
             raise api_provider.RequestCancelledError("stopped")
-        turn = await asyncio.to_thread(
-            api_provider.chat_turn_with_tools,
-            config.TASK_CHAT, list(messages), specs,
-            model_ref=model_ref, cancellation_event=cancel_event,
-            settings_manager=settings_manager, runtime=runtime,
+        turn = await asyncio.wait_for(
+            asyncio.to_thread(
+                api_provider.chat_turn_with_tools,
+                config.TASK_CHAT, list(messages), specs,
+                model_ref=model_ref, cancellation_event=cancel_event,
+                settings_manager=settings_manager, runtime=runtime,
+            ),
+            timeout=_agents.WATCHDOG_TIMEOUT_SECONDS,
         )
         last_text = turn["message"]["content"] or ""
         tool_calls: list[ToolCall] = turn["tool_calls"]
@@ -184,6 +195,15 @@ def register_subagent_tool(registry: ToolRegistry) -> None:
                 settings_manager=getattr(ctx, "settings_manager", None),
                 runtime=getattr(ctx, "runtime", None),
                 cancel_event=ctx.cancel.event if ctx.cancel is not None else None,
+            )
+        except asyncio.TimeoutError:
+            # The watchdog fired. Reported as an ordinary tool error (the
+            # parent decides whether to retry, narrow the task, or do the
+            # work itself) rather than as a bare empty exception string,
+            # which is all str(TimeoutError()) would have produced.
+            return ToolResult(
+                content="The subagent timed out waiting for the model and was abandoned.",
+                is_error=True,
             )
         except Exception as exc:
             from api_provider import RequestCancelledError

--- a/backend/harness/tools_python.py
+++ b/backend/harness/tools_python.py
@@ -75,28 +75,47 @@ class PythonReplRegistry:
     """
 
     def __init__(self) -> None:
-        self._repls: dict[str, PythonREPL] = {}
+        # Value is (repl, cwd): the cwd is kept so a rebound workspace can
+        # be detected - see get().
+        self._repls: dict[str, tuple[PythonREPL, Path]] = {}
         self._lock = threading.RLock()
 
     def get(self, workspace_id: str, cwd: Path, *, manage_cwd: bool) -> PythonREPL:
+        """The workspace's interpreter, started on first use.
+
+        A REPL's cwd is fixed at spawn, so an interpreter kept across a
+        REBINDING (the node moves between scratch and a user's project
+        folder) would keep executing in the old directory while fs.read and
+        shell.exec had already moved to the new one - `open("data.csv")`
+        silently reading a different file than `fs.read("data.csv")`. The
+        cwd is therefore part of the cache key in effect: a changed root
+        retires the old interpreter rather than reusing it.
+        """
         with self._lock:
-            repl = self._repls.get(workspace_id)
-            if repl is None:
-                repl = PythonREPL(repl_id=workspace_id, cwd=cwd, manage_cwd=manage_cwd)
-                self._repls[workspace_id] = repl
-            return repl
+            stale = self._repls.get(workspace_id)
+            if stale is not None and stale[1] == cwd:
+                return stale[0]
+            # Replace the entry under the lock, so two callers can never
+            # race two interpreters into one workspace; the retired one is
+            # stopped outside it, since killing a process is slow and no
+            # other workspace should wait on it.
+            repl = PythonREPL(repl_id=workspace_id, cwd=cwd, manage_cwd=manage_cwd)
+            self._repls[workspace_id] = (repl, cwd)
+        if stale is not None:
+            stale[0].stop()
+        return repl
 
     def stop_workspace(self, workspace_id: str) -> None:
         with self._lock:
-            repl = self._repls.pop(workspace_id, None)
-        if repl is not None:
-            repl.stop()
+            entry = self._repls.pop(workspace_id, None)
+        if entry is not None:
+            entry[0].stop()
 
     def stop_all(self) -> None:
         with self._lock:
-            repls = list(self._repls.values())
+            entries = list(self._repls.values())
             self._repls.clear()
-        for repl in repls:
+        for repl, _cwd in entries:
             repl.stop()
 
 

--- a/backend/harness/tools_shell.py
+++ b/backend/harness/tools_shell.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 import sys
+import threading
 import time
 
 from pathlib import Path
@@ -60,6 +61,10 @@ SHELL_EXEC_TIMEOUT_SECONDS = 120
 _OUTPUT_CAP_CHARS = 20_000
 _COMMAND_CAP_CHARS = 4_000
 _POLL_SECONDS = 0.2
+# How long the exit path waits for the reader thread to finish the tail
+# already in the pipe. Short: the process has already exited, so the pipe
+# is closed and the read is draining a buffer, not waiting on anyone.
+_READER_JOIN_SECONDS = 2.0
 
 SHELL_EXEC_SPEC = ToolSpec(
     name="shell.exec",
@@ -82,7 +87,16 @@ SHELL_EXEC_SPEC = ToolSpec(
 def _run_command(command: str, cwd, cancel_event) -> tuple[str, "int | None", str]:
     """Blocking worker (called via to_thread): returns (output, exit_code,
     ended) where ended is "ok" | "timeout" | "cancelled". guard-then-Popen,
-    then a poll loop so cancel/timeout kill the whole tree promptly."""
+    then a poll loop so cancel/timeout kill the whole tree promptly.
+
+    Output is drained CONCURRENTLY by a reader thread (the shell_sessions
+    posture) rather than read once after exit: an OS pipe buffer is ~64KB,
+    so a command that writes more than that blocks forever on write with
+    nobody reading, and the poll loop below then reports a timeout for a
+    command that had in fact done its work - `npm ci`, a test run, any
+    real build. The reader also means the timeout path can hand back what
+    the command managed to say before it was killed, which is the whole
+    diagnostic value of a hung command."""
     kwargs = {"env": safe_subprocess_env()}
     if sys.platform == "win32":
         kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
@@ -106,19 +120,39 @@ def _run_command(command: str, cwd, cancel_event) -> tuple[str, "int | None", st
             **kwargs,
         )
         guard.assign(process.pid)
+        chunks: list[str] = []
+        stream = process.stdout
+
+        def _drain() -> None:
+            """Reader thread: keeps the pipe empty so the child never
+            blocks on write. Buffering stops just past the caller's own
+            display cap - reading CONTINUES past it (a discarded read
+            still unblocks the writer), so a chatty command is bounded in
+            memory without being bounded in progress."""
+            if stream is None:
+                return
+            buffered = 0
+            try:
+                for line in stream:
+                    if buffered <= _OUTPUT_CAP_CHARS:
+                        chunks.append(line)
+                        buffered += len(line)
+            except (ValueError, OSError):
+                return
+
+        reader = threading.Thread(target=_drain, name="shell-exec-reader", daemon=True)
+        reader.start()
         deadline = time.monotonic() + SHELL_EXEC_TIMEOUT_SECONDS
-        # communicate() in a nested thread would be a second thread per
-        # call; polling with a bounded read at the end is enough because
-        # the pipe buffer is drained once the process exits, and a child
-        # that fills the pipe and blocks still hits the timeout kill.
         while True:
             if process.poll() is not None:
-                output = process.stdout.read() if process.stdout else ""
-                return output, process.returncode, "ok"
+                # The process is gone; give the reader a moment to finish
+                # the tail already sitting in the pipe before joining it.
+                reader.join(timeout=_READER_JOIN_SECONDS)
+                return "".join(chunks), process.returncode, "ok"
             if cancel_event is not None and cancel_event.is_set():
                 return "", None, "cancelled"
             if time.monotonic() > deadline:
-                return "", None, "timeout"
+                return "".join(chunks), None, "timeout"
             time.sleep(_POLL_SECONDS)
     finally:
         # Kills the whole tree for the cancelled/timeout paths; a no-op
@@ -302,13 +336,17 @@ def register_harness_shell_tool(registry: ToolRegistry, sessions: "ShellSessionR
             # The one exception invoke() propagates - cancellation is the
             # loop's mechanism, never a tool "error" fed to the model.
             raise RequestCancelledError("stopped")
-        if ended == "timeout":
-            return ToolResult(
-                content=f"Command timed out after {SHELL_EXEC_TIMEOUT_SECONDS}s and was killed.",
-                is_error=True,
-            )
         if len(output) > _OUTPUT_CAP_CHARS:
             output = output[:_OUTPUT_CAP_CHARS] + f"\n…[truncated at {_OUTPUT_CAP_CHARS} characters]"
+        if ended == "timeout":
+            # Whatever it printed before it was killed is the diagnostic -
+            # a build that hung after 300 lines of progress is a different
+            # problem from one that hung with nothing to say.
+            killed = f"Command timed out after {SHELL_EXEC_TIMEOUT_SECONDS}s and was killed."
+            return ToolResult(
+                content=f"{killed}\n{output}" if output else killed,
+                is_error=True,
+            )
         return ToolResult(
             content=f"exit code {exit_code}\n{output}" if output else f"exit code {exit_code} (no output)",
             is_error=bool(exit_code),

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -2425,8 +2425,15 @@ def test_the_yield_still_works_on_a_LATER_autosave_tick_not_just_the_first(db_pa
             document.add_chat_node(300, 0, "a second message", is_user=True)
             assert await _await_owner(AUTOSAVE_OWNER), "no second tick"
 
+            # Generously above chat_library.AUTOSAVE_YIELD_TIMEOUT_SECONDS
+            # (2.0s), which is exactly the wait this intent may legitimately
+            # sit through: a bound TIGHTER than the production wait fails on
+            # correct behavior whenever a loaded runner is slow to schedule
+            # the release - which is how this flaked in CI. The bound exists
+            # to fail instead of hanging, not to assert a latency.
             await asyncio.wait_for(
-                bus.dispatch_intent("app-chat-library", "saveChat", []), timeout=1.0
+                bus.dispatch_intent("app-chat-library", "saveChat", []),
+                timeout=chat_library_module.AUTOSAVE_YIELD_TIMEOUT_SECONDS * 5,
             )
         finally:
             bus.autosave_task.cancel()

--- a/backend/tests/test_harness.py
+++ b/backend/tests/test_harness.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+import time
 
 import pytest
 
@@ -247,6 +248,26 @@ class TestLoop:
         assert "first question" in contents and "first answer" in contents
         assert node.state.harness_reply == "second answer"
 
+    def test_the_task_message_enters_history_exactly_once(self, workspace_root, monkeypatch):
+        """load_messages crosses the flush barrier itself, so a task message
+        appended BEFORE the reload comes back in it. Appending after the
+        load is what keeps the model from seeing the request twice on every
+        turn of every task."""
+        document, dispatcher, registry, bus, node = self._make(workspace_root)
+        seen: list[list] = []
+
+        def recording_turn(task, messages, tools=(), **kwargs):
+            seen.append(list(messages))
+            return {"message": {"content": "answer", "role": "assistant"}, "tool_calls": [], "usage": None}
+
+        monkeypatch.setattr(api_provider, "chat_turn_with_tools", recording_turn)
+        asyncio.run(drive(document, dispatcher, registry, bus, node, "only ask me once"))
+
+        sent = [m.get("content") for m in seen[0]]
+        assert sent.count("only ask me once") == 1
+        ws = ensure_workspace(node.state.harness_workspace_id)
+        assert [m["content"] for m in load_messages(ws)].count("only ask me once") == 1
+
     def test_turn_cap_lands_failed_and_resumable(self, workspace_root, monkeypatch):
         document, dispatcher, registry, bus, node = self._make(workspace_root)
         node.state.harness_max_turns = 2
@@ -420,6 +441,29 @@ class TestShellTool:
 
         result = asyncio.run(go())
         assert "ABSENT" in result.content and "sk-secret" not in result.content
+
+    def test_large_output_comes_back_instead_of_filling_the_pipe(self, workspace_root):
+        """An OS pipe buffer is ~64KB. Without a concurrent reader the child
+        blocks on write once it is full, and a command that had in fact
+        finished its work reports as a timeout with no output at all - the
+        shape of every real build or test run."""
+        ensure_workspace("ws1")
+        registry, ctx = self._setup()
+        emit = (
+            "python -c \"import sys; "
+            "sys.stdout.write(('y'*200 + chr(10))*1000)\""
+        )
+
+        async def go():
+            return await registry.invoke(call("1", "shell.exec", command=emit), ctx)
+
+        started = time.monotonic()
+        result = asyncio.run(go())
+        elapsed = time.monotonic() - started
+        assert "timed out" not in result.content
+        assert "exit code 0" in result.content
+        assert "yyy" in result.content
+        assert elapsed < 30, "a drained pipe finishes at the command's own speed"
 
     def test_denied_command_never_spawns(self, workspace_root):
         ws = ensure_workspace("ws1")

--- a/backend/tests/test_harness_h6.py
+++ b/backend/tests/test_harness_h6.py
@@ -118,6 +118,17 @@ class TestShellPolicy:
         assert plan.dangerous == ["rm -rf node_modules"]
         assert "rm -rf node_modules" in plan.disclosure()
 
+    def test_a_single_ampersand_chain_is_split_too(self):
+        """`&` chains on both shells this app spawns - it is cmd.exe's
+        ordinary sequential separator and POSIX sh's background operator -
+        so a command after it runs either way. Unsplit, its tail is neither
+        disclosed in the approval prompt nor dangerous-checked, which is
+        the exact hiding place segmentation exists to close."""
+        plan = analyze("echo building & rm -rf out")
+        assert plan.segments == ["echo building", "rm -rf out"]
+        assert plan.dangerous == ["rm -rf out"]
+        assert is_dangerous_command("echo building & rm -rf out")
+
     @pytest.mark.parametrize(
         "command",
         [
@@ -333,6 +344,30 @@ class TestPythonExec:
             assert not result.is_error
             assert "ZeroDivisionError" in result.content
             assert "[code raised]" in result.content
+        finally:
+            repls.stop_all()
+
+    def test_a_rebound_workspace_retires_the_old_interpreter(self, tmp_path):
+        """A REPL's cwd is fixed at spawn. Keeping one across a rebinding
+        (scratch <-> a user's project folder) would leave python.exec
+        executing in a different directory than fs.* and shell.exec, so
+        open('x') and fs.read('x') would silently mean different files."""
+        registry, repls, workspace = self._setup(tmp_path)
+        second = tmp_path / "other-ws"
+        second.mkdir()
+        try:
+            first_repl = repls.get("ws-h6", workspace, manage_cwd=True)
+            assert repls.get("ws-h6", workspace, manage_cwd=True) is first_repl, "same root reuses it"
+
+            rebound = repls.get("ws-h6", second, manage_cwd=False)
+            assert rebound is not first_repl
+
+            result = _invoke(
+                registry, "python.exec",
+                {"code": "import os; print(os.path.basename(os.getcwd()))"},
+                _tool_ctx(second),
+            )
+            assert result.content.strip() == "other-ws"
         finally:
             repls.stop_all()
 

--- a/backend/tests/test_harness_subagents.py
+++ b/backend/tests/test_harness_subagents.py
@@ -5,6 +5,7 @@ the end-to-end spawn through the parent loop."""
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
@@ -107,6 +108,44 @@ def test_turn_limit_returns_the_last_text_flagged(workspace_root, monkeypatch):
         run_subagent(registry=registry, workspace_dir=ensure_workspace("ws1"), task="loop", max_turns=2)
     )
     assert "turn limit" in answer
+
+
+def test_a_hung_model_call_trips_the_watchdog_instead_of_hanging_the_parent(
+    workspace_root, monkeypatch,
+):
+    """The parent is blocked inside registry.invoke while a subagent runs,
+    so the parent's own wait_for is not covering the child's model call. A
+    provider that accepts the connection and never answers would otherwise
+    hang the whole run with Stop as the only way out."""
+    from backend import agents as agents_module
+
+    ensure_workspace("ws1")
+    registry = full_registry()
+    monkeypatch.setattr(agents_module, "WATCHDOG_TIMEOUT_SECONDS", 0.2)
+
+    def never_answers(task, messages, tools=(), **kwargs):
+        # Sleeps well past the (shrunk) watchdog. It cannot be interrupted -
+        # to_thread has no cancellation - so the elapsed check below is taken
+        # INSIDE the loop, where the watchdog's own effect is visible;
+        # asyncio.run itself still joins this thread on the way out.
+        time.sleep(3)
+        raise AssertionError("the watchdog should have fired long before this")
+
+    monkeypatch.setattr(api_provider, "chat_turn_with_tools", never_answers)
+
+    async def go():
+        ctx = HarnessRunContext(
+            granted_scopes=frozenset({"provider.call"}),
+            request_approval=None,
+            harness_workspace_id="ws1",
+        )
+        started = time.monotonic()
+        result = await registry.invoke(call("1", "subagent.spawn", task="investigate"), ctx)
+        return result, time.monotonic() - started
+
+    result, elapsed = asyncio.run(go())
+    assert elapsed < 2, "the spawn returns on the watchdog, not on the hung call"
+    assert result.is_error and "timed out" in result.content
 
 
 def test_parent_loop_spawns_a_subagent_and_gets_its_summary(workspace_root, monkeypatch):

--- a/web_ui/src/app/canvas/HarnessNodeView.test.tsx
+++ b/web_ui/src/app/canvas/HarnessNodeView.test.tsx
@@ -244,7 +244,26 @@ describe("HarnessNodeView", () => {
     expect(screen.getByText(/C:\/proj/)).toBeInTheDocument();
     expect(screen.queryByText(/not trusted/)).not.toBeInTheDocument();
 
-    // Bound but not trusted on this machine: pending warning shown.
+    // Bound but not trusted on this machine: the run bound the scratch dir
+    // instead, so the active root does not match the request - warning shown.
+    rerender(
+      <ReactFlowProvider>
+        <HarnessNodeView
+          id="n1" type="harness"
+          data={makeData({
+            harnessStatus: "done", pendingRequestId: null,
+            harnessWorkspacePath: "C:/proj",
+            harnessWorkspaceActive: "C:/scratch/harness/ws1",
+          })}
+          selected={false} isConnectable={false} positionAbsoluteX={0} positionAbsoluteY={0}
+          zIndex={0} dragging={false} deletable selectable draggable parentId={undefined}
+        />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByText(/not trusted on this machine/)).toBeInTheDocument();
+
+    // Just picked, nothing run yet: an empty active root means "no run has
+    // bound this node", not "the grant was refused". Warning would be a lie.
     rerender(
       <ReactFlowProvider>
         <HarnessNodeView
@@ -258,7 +277,8 @@ describe("HarnessNodeView", () => {
         />
       </ReactFlowProvider>,
     );
-    expect(screen.getByText(/not trusted on this machine/)).toBeInTheDocument();
+    expect(screen.getByText(/C:\/proj/)).toBeInTheDocument();
+    expect(screen.queryByText(/not trusted/)).not.toBeInTheDocument();
   });
 
   it("renders activity rows with error styling on failures", () => {

--- a/web_ui/src/app/canvas/HarnessNodeView.tsx
+++ b/web_ui/src/app/canvas/HarnessNodeView.tsx
@@ -212,9 +212,11 @@ function HarnessNodeViewInner({ data, selected }: NodeProps<HarnessFlowNode>) {
 
       {/* Workspace binding. harnessWorkspacePath is the REQUEST (what the
           node asks for); a run only honors it if the folder is trusted, and
-          reports the truth in harnessWorkspaceActive. So a bound path with
-          no matching active dir after a run means the grant did not apply on
-          this machine - shown as pending rather than as if it were live. */}
+          reports the root it actually bound in harnessWorkspaceActive. So a
+          NON-EMPTY active dir that does not match the request means a run
+          happened and the grant did not apply on this machine. An empty one
+          means no run has bound this node since the folder was picked -
+          nothing has been refused yet, so nothing is warned about. */}
       <div className="harness-node-workspace">
         {data.harnessWorkspacePath ? (
           <>
@@ -224,6 +226,7 @@ function HarnessNodeViewInner({ data, selected }: NodeProps<HarnessFlowNode>) {
             >
               📁 {data.harnessWorkspacePath}
               {!running &&
+                data.harnessWorkspaceActive !== "" &&
                 data.harnessWorkspaceActive !== data.harnessWorkspacePath &&
                 " (not trusted on this machine — using scratch)"}
             </span>


### PR DESCRIPTION
## Problem

A QA pass over `backend/harness/` — the newest subsystem and the least covered by tests (`harness/loop.py` 72%, `tools_fs.py` 73%, `agent_dispatch/harness.py` 18%) — found six defects. None was covered by an existing test.

**1. Every task's own message reached the model twice.** `run_harness` appended the new user message to the transcript and then reloaded history to rebuild context. `load_messages` crosses the flush barrier itself, so the just-appended message was already on disk when the reload ran, came back in it, and was then appended a second time. Every turn of every task carried the request duplicated.

**2. A dangerous command after `&` was neither disclosed nor re-prompted.** `shell_policy` segments on `&&`, `||`, `|`, `;` and newline, but not on a bare `&` — cmd.exe's ordinary sequential separator and POSIX sh's background operator. `echo building & rm -rf out` was analyzed as one benign `echo` segment: the approval panel disclosed no delete, the dangerous-command rule did not force a fresh prompt, and the session-grant button was offered. This is the exact "dangerous tail hiding behind a benign head" the module exists to prevent.

**3. `shell.exec` deadlocked on any command producing more than ~64KB of output.** Output was read once after the process exited, so a child that filled the OS pipe buffer blocked on write with nobody reading, ran out the 120s timeout, and was killed — the tool then reported a timeout and *no output at all* for a command that had in fact completed its work. That is the ordinary shape of `npm ci`, a test run, or any real build. Reproduced directly: 200KB of output took the full 120s and returned 0 characters.

**4. The agent card warned "not trusted on this machine" the moment a folder was picked.** The warning fired whenever the last run's bound root differed from the requested path — which includes the case where no run has bound the node yet. Picking a folder that *was* successfully granted immediately displayed a message saying the grant had not applied.

**5. `python.exec` kept executing in the old directory after a rebinding.** The REPL is cached per workspace id, but its cwd is fixed at spawn. After a node moved between scratch and a project folder, `open("data.csv")` inside `python.exec` and `fs.read("data.csv")` silently referred to different files — breaking the invariant the module's own docstring states.

**6. A hung provider call inside a subagent hung the entire run.** The parent loop wraps its own model calls in the watchdog, but while a subagent runs the parent is blocked inside `registry.invoke`, so the child's unwrapped calls had no timeout. A provider that accepts the connection and never answers left Stop as the only way out.

**7. A pre-existing flaky test went red on this PR's first CI run.** `test_the_yield_still_works_on_a_LATER_autosave_tick_not_just_the_first` bounds the `saveChat` intent at 1.0s, but that intent legitimately waits up to `chat_library.AUTOSAVE_YIELD_TIMEOUT_SECONDS` (2.0s) for the autosave guard to be released — the very behavior the test exists to pin. A bound tighter than the production wait fails on correct behavior whenever a loaded runner is slow to schedule the release. Unrelated to the harness; fixed here because it broke this PR's CI.

## Change

- `harness/loop.py` — load prior history before appending the task message; record the root each run actually binds (scratch included) in `harness_workspace_active`.
- `harness/shell_policy.py` — add the bare `&` to the separator set.
- `harness/tools_shell.py` — drain `shell.exec` output on a concurrent reader thread, bounded just past the display cap; return partial output on the timeout path.
- `harness/tools_python.py` — key the REPL cache on (workspace id, cwd) in effect: a changed root retires the old interpreter rather than reusing it.
- `harness/subagents.py` — apply the same watchdog to the child's model calls and report a fired watchdog as an ordinary tool error.
- `api/intents_harness.py` — clear `harness_workspace_active` when a node is rebound, so a stale result is never read as a verdict on a newer binding.
- `canvas/HarnessNodeView.tsx` — warn only on a real mismatch, never on an empty (no-run-yet) active root.
- `domain/node_states.py` — the field comment restated to match.
- `tests/test_chat_library.py` — the flaky bound now derives from `AUTOSAVE_YIELD_TIMEOUT_SECONDS` instead of restating a tighter number, so it cannot drift apart from it again.

Six regression tests, one per defect; each fails against the current `main`.

## Test plan

- CI: all four jobs green on the head commit (Python checks / build check / frontend checks / E2E).
- `python -m pytest -q` from the repo root — 3084 passed, 19 skipped. One unrelated flake (`mutation_tests/test_chart_data_properties.py::test_canonicalize_chart_data_does_not_mutate_its_input`) tripped Hypothesis's 200ms per-example deadline under `-n auto` contention and passes in isolation; the local profile deliberately keeps that deadline while CI sets `CI=true` and runs with `deadline=None`, so CI is unaffected.
- `python -m ruff check .` and `python -m mypy` — clean.
- `cd web_ui && npm run check` — 2036 vitest tests across 85 files, typecheck, lint, build, bundle check all pass.
- Defects 1 and 3 were reproduced directly before fixing: the transcript reload returned the user message twice, and 200KB of `shell.exec` output timed out at 120s with an empty result.

