### PR TITLE
Remove the friction from starting and watching an agent

### DIFF
--- a/backend/api/intents_harness.py
+++ b/backend/api/intents_harness.py
@@ -26,6 +26,10 @@ _DEFAULT_TURNS = 16
 # One user message's own bound - the same wire-input-is-untrusted posture
 # every other intent that accepts free text takes.
 _MESSAGE_CAP = 20_000
+# A filesystem path's own bound. Same posture as _MESSAGE_CAP: the launcher
+# hands this across the wire, so it is untrusted length as well as untrusted
+# content (the trust list is what settles the content, at run time).
+_PATH_CAP = 4_000
 
 
 def _place_harness_node(document: SceneDocument) -> tuple[float, float]:
@@ -43,7 +47,7 @@ def register_harness_intents(
 ) -> None:
     publish_scene = make_publish_scene(bus)
 
-    async def start(goal, max_turns=None):
+    async def start(goal, max_turns=None, workspace_path=None):
         goal_text = str(goal or "").strip()[:_MESSAGE_CAP]
         if not goal_text:
             notifications.show("Give the agent a task first.", "info")
@@ -61,6 +65,16 @@ def register_harness_intents(
             "harnessCreate", "agent",
             lambda: document.add_harness_node(x, y, goal_text, max_turns=clamp(max_turns)),
         )
+        # The launcher's folder choice, bound BEFORE the run starts so the
+        # first task already works where the person meant it to - without
+        # this they had to let a scratch run finish, rebind the node, and
+        # re-send the same task. Wire input is a REQUEST, never a grant:
+        # bound_root re-checks the trust list at run time and silently
+        # falls back to scratch, so a path that was never picked here
+        # (a hand-edited session file, a replayed intent) buys nothing.
+        requested_workspace = str(workspace_path or "").strip()[:_PATH_CAP]
+        if requested_workspace:
+            node.state.harness_workspace_path = requested_workspace
         await publish_scene()
 
         request_id = await agent_dispatcher.start_harness_run(
@@ -97,6 +111,43 @@ def register_harness_intents(
     async def cancel(request_id):
         agent_dispatcher.cancel_harness(request_id)
 
+    async def _pick_and_grant(start_in: str) -> "str | None":
+        """Open the folder picker and, on a real choice, grant that folder.
+
+        The pick IS the consent (the gitlink local-root precedent), so the
+        two steps are one operation and live in one place - both the
+        per-node binding and the launcher below call this rather than each
+        implementing "picker, then trust list" their own way.
+        """
+        try:
+            folder = await native_dialogs.pick_folder(directory=start_in)
+        except Exception as exc:  # noqa: BLE001 - a local folder path, not a credential
+            notifications.show(f"Could not open the folder picker: {exc}", "error")
+            await bus.publish("notification")
+            return None
+        if not folder:
+            return None
+        resolved = str(Path(folder).resolve())
+        settings = agent_dispatcher._settings_manager
+        if settings is not None:
+            # The grant write goes through the same locked writer every
+            # other settings mutation uses (save_recipe's precedent), so it
+            # cannot land mid-write against a concurrent settings save.
+            await asyncio.to_thread(run_locked, lambda: settings.add_harness_trusted_dir(resolved))
+        return resolved
+
+    async def pick_launch_workspace():
+        """The launcher's folder choice, before any node exists.
+
+        Same picker and same grant as pick_workspace below; it just has no
+        node to write to, so it ANSWERS with the folder and lets `start`
+        carry it in. Split from pick_workspace rather than made to accept a
+        null node id: "which folder should the new agent use" and "rebind
+        this existing agent" are different operations, and one of them
+        must not silently become the other on a stale node id.
+        """
+        return await _pick_and_grant(os.path.expanduser("~"))
+
     async def pick_workspace(node_id):
         """Bind this agent node to a real project directory. The pick IS
         the consent (the gitlink local-root precedent): on success we add
@@ -108,21 +159,9 @@ def register_harness_intents(
         if node is None or not isinstance(node.state, HarnessState):
             return
         directory = node.state.harness_workspace_path or os.path.expanduser("~")
-        try:
-            folder = await native_dialogs.pick_folder(directory=directory)
-        except Exception as exc:  # noqa: BLE001 - a local folder path, not a credential
-            notifications.show(f"Could not open the folder picker: {exc}", "error")
-            await bus.publish("notification")
+        resolved = await _pick_and_grant(directory)
+        if resolved is None:
             return
-        if not folder:
-            return
-        resolved = str(Path(folder).resolve())
-        settings = agent_dispatcher._settings_manager
-        if settings is not None:
-            # The grant write goes through the same locked writer every
-            # other settings mutation uses (save_recipe's precedent), so it
-            # cannot land mid-write against a concurrent settings save.
-            await asyncio.to_thread(run_locked, lambda: settings.add_harness_trusted_dir(resolved))
         node.state.harness_workspace_path = resolved
         # The previous run's bound root says nothing about THIS binding -
         # left in place it reads as "the grant did not apply", which is
@@ -170,5 +209,6 @@ def register_harness_intents(
     bus.register_intent("harness", "denyTool", deny_tool)
     bus.register_intent("harness", "approveToolForSession", approve_tool_for_session)
     bus.register_intent("harness", "answer", answer_question)
+    bus.register_intent("harness", "pickLaunchWorkspace", pick_launch_workspace)
     bus.register_intent("harness", "pickWorkspace", pick_workspace)
     bus.register_intent("harness", "useScratch", use_scratch)

--- a/backend/tests/test_harness_user_dirs.py
+++ b/backend/tests/test_harness_user_dirs.py
@@ -94,3 +94,117 @@ def test_scratch_resolve_helper_still_confines(workspace_root):
     ensure_workspace("ws1")
     with pytest.raises(workspace_module.WorkspaceError):
         resolve_under_root(workspace_module.workspace_dir("ws1"), "../elsewhere")
+
+
+# -- the launcher's own workspace choice ------------------------------------
+#
+# Binding a folder only AFTER the node existed meant the first run of every
+# real piece of work went to scratch: you had to let it finish, rebind, and
+# re-send the same task. These cover the launch-time path that removes that,
+# and the fact that it buys no trust the per-node path did not already.
+
+
+class _FakeBus:
+    """Enough SessionBus for the two intents under test."""
+
+    def __init__(self):
+        self.intents = {}
+        self.published = []
+
+    def register_intent(self, topic, name, fn):
+        self.intents[(topic, name)] = fn
+
+    async def publish(self, topic):
+        self.published.append(topic)
+
+    async def dispatch(self, topic, name, args):
+        return await self.intents[(topic, name)](*args)
+
+
+class _RecordingSettings(FakeSettings):
+    def __init__(self, trusted=()):
+        super().__init__(trusted)
+        self.granted = []
+
+    def add_harness_trusted_dir(self, path):
+        self.granted.append(path)
+        self._trusted.append(path)
+
+
+def _harness_bus(monkeypatch, settings, picked=None):
+    from backend import native_dialogs
+    from backend.api.intents_harness import register_harness_intents
+    from backend.domain.graph import SceneDocument
+    from backend.notifications import NotificationState
+
+    async def fake_pick_folder(directory=None):
+        return picked
+
+    monkeypatch.setattr(native_dialogs, "pick_folder", fake_pick_folder)
+    bus, document = _FakeBus(), SceneDocument()
+    dispatcher = type("D", (), {"_settings_manager": settings, "start_harness_run": None})()
+
+    async def start_harness_run(**kwargs):
+        dispatcher.started = kwargs
+        return "run-1"
+
+    dispatcher.start_harness_run = start_harness_run
+    register_harness_intents(bus, document, NotificationState(), dispatcher)
+    return bus, document
+
+
+def test_the_launcher_binds_its_folder_before_the_first_run(workspace_root, tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    settings = _RecordingSettings([str(project.resolve())])
+    bus, document = _harness_bus(monkeypatch, settings)
+
+    node_id = asyncio.run(bus.dispatch("harness", "start", ["do the thing", 8, str(project)]))
+
+    node = document.nodes[node_id]
+    assert node.state.harness_workspace_path == str(project)
+    # Bound BEFORE the run: the first task already works in the right place.
+    root, is_user_dir = bound_root(
+        node.state.harness_workspace_id, node.state.harness_workspace_path,
+        settings_manager=settings,
+    )
+    assert is_user_dir and root == project.resolve()
+
+
+def test_a_launcher_path_is_a_request_not_a_grant(workspace_root, tmp_path, monkeypatch):
+    """The wire can name any folder; naming it must not make it trusted.
+    The run-time gate is what settles it, exactly as for a session file."""
+    project = tmp_path / "not-granted"
+    project.mkdir()
+    bus, document = _harness_bus(monkeypatch, _RecordingSettings([]))
+
+    node_id = asyncio.run(bus.dispatch("harness", "start", ["do the thing", 8, str(project)]))
+
+    node = document.nodes[node_id]
+    root, is_user_dir = bound_root(
+        node.state.harness_workspace_id, node.state.harness_workspace_path,
+        settings_manager=_RecordingSettings([]),
+    )
+    assert not is_user_dir and root == ensure_workspace(node.state.harness_workspace_id)
+
+
+def test_picking_a_launch_workspace_grants_it_and_answers_with_the_path(
+    workspace_root, tmp_path, monkeypatch,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    settings = _RecordingSettings([])
+    bus, _document = _harness_bus(monkeypatch, settings, picked=str(project))
+
+    answer = asyncio.run(bus.dispatch("harness", "pickLaunchWorkspace", []))
+
+    assert answer == str(project.resolve())
+    assert settings.granted == [str(project.resolve())], "the pick IS the grant"
+
+
+def test_a_cancelled_launch_picker_grants_nothing(workspace_root, monkeypatch):
+    settings = _RecordingSettings([])
+    bus, _document = _harness_bus(monkeypatch, settings, picked=None)
+
+    assert asyncio.run(bus.dispatch("harness", "pickLaunchWorkspace", [])) is None
+    assert settings.granted == []

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -271,10 +271,14 @@ def test_the_scan_finds_the_real_population_of_registered_intents():
     # (approveCodeExecution/denyCodeExecution stayed registered - they
     # relocated to backend/api/intents_code_sandbox.py, not deleted), and
     # 176 -> 178 when H6 added harness/approveToolForSession (§2.4's
-    # graded consent) and harness/answer (§2.3's user.ask resolution).
+    # graded consent) and harness/answer (§2.3's user.ask resolution), and
+    # 178 -> 179 when the agent launcher grew its own workspace pick
+    # (harness/pickLaunchWorkspace - the node-less sibling of
+    # harness/pickWorkspace, so the first run can already be bound to the
+    # right folder instead of spending itself in scratch).
     real = _collect_real_registrations()
-    assert len(real) == 178, (
-        f"expected exactly 178 real registered intents, found {len(real)} - "
+    assert len(real) == 179, (
+        f"expected exactly 179 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -269,6 +269,7 @@ CLASSIFICATION: tuple[Classified, ...] = (
     Classified("harness", "denyTool", "B", "security: harness tool-call approval gate"),
     Classified("harness", "approveToolForSession", "B", "security: harness tool-call approval gate, session-scoped grant (PLAN §2.4 graded consent)"),
     Classified("harness", "answer", "B", "run-lifecycle: resolves a run parked on user.ask with the user's typed answer; the answer enters the workspace transcript, not the document"),
+    Classified("harness", "pickLaunchWorkspace", "B", "run-config: the launcher's folder pick, before any node exists - writes the settings trust grant and answers with the path, touching no document content"),
     Classified("harness", "pickWorkspace", "B", "run-config: binds the node to a trusted user dir and writes the settings trust grant, not document content"),
     Classified("harness", "useScratch", "B", "run-config: reverts the node to the scratch workspace"),
 

--- a/web_ui/src/app/canvas/HarnessNodeView.test.tsx
+++ b/web_ui/src/app/canvas/HarnessNodeView.test.tsx
@@ -295,3 +295,78 @@ describe("HarnessNodeView", () => {
     expect(screen.getByText("Invalid regular expression")).toBeInTheDocument();
   });
 });
+
+describe("HarnessNodeView — the run is parked on a human", () => {
+  it("says so in the status band instead of claiming to be working", () => {
+    // A parked run is still `running` on the wire, so the band used to read
+    // "Working…" while the only thing standing between it and progress was
+    // the person reading that word.
+    const { rerender } = renderHarness(
+      makeData({
+        harnessStatus: "running",
+        harnessAwaitingApproval: true,
+        harnessApprovalToolName: "shell.exec",
+        harnessApprovalSummary: "shell.exec\n  npm test",
+      }),
+    );
+    expect(screen.getByText("Waiting for your approval")).toBeInTheDocument();
+    expect(screen.queryByText("Working…")).not.toBeInTheDocument();
+
+    rerender(
+      <ReactFlowProvider>
+        <HarnessNodeView
+          id="n1" type="harness"
+          data={makeData({
+            harnessStatus: "running",
+            harnessAwaitingQuestion: true,
+            harnessQuestion: "Which database should I target?",
+          })}
+          selected={false} isConnectable={false} positionAbsoluteX={0} positionAbsoluteY={0}
+          zIndex={0} dragging={false} deletable selectable draggable parentId={undefined}
+        />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByText("Waiting for your answer")).toBeInTheDocument();
+  });
+
+  it("still reads as working when it really is", () => {
+    renderHarness(makeData({ harnessStatus: "running" }));
+    expect(screen.getByText("Working…")).toBeInTheDocument();
+  });
+});
+
+describe("HarnessNodeView — activity visibility", () => {
+  const activity = [{ tool: "fs.list", summary: "{}", outcome: "ok", elapsedMs: 4 }];
+
+  it("opens the activity log on a run's first tool call", () => {
+    // "What is it doing?" is the question a running agent raises; the answer
+    // was behind a closed <details> nobody thought to click.
+    const { container } = renderHarness(
+      makeData({ harnessStatus: "running", harnessActivity: activity }),
+    );
+    expect(container.querySelector("details.plan-node-activity")).toHaveProperty("open", true);
+  });
+
+  it("does not spring back open after the user collapses it mid-run", () => {
+    const { container, rerender } = renderHarness(
+      makeData({ harnessStatus: "running", harnessActivity: activity }),
+    );
+    const details = container.querySelector("details.plan-node-activity") as HTMLDetailsElement;
+    details.open = false;
+
+    rerender(
+      <ReactFlowProvider>
+        <HarnessNodeView
+          id="n1" type="harness"
+          data={makeData({
+            harnessStatus: "running",
+            harnessActivity: [...activity, { tool: "fs.read", summary: "{}", outcome: "ok", elapsedMs: 9 }],
+          })}
+          selected={false} isConnectable={false} positionAbsoluteX={0} positionAbsoluteY={0}
+          zIndex={0} dragging={false} deletable selectable draggable parentId={undefined}
+        />
+      </ReactFlowProvider>,
+    );
+    expect(details.open).toBe(false);
+  });
+});

--- a/web_ui/src/app/canvas/HarnessNodeView.tsx
+++ b/web_ui/src/app/canvas/HarnessNodeView.tsx
@@ -123,6 +123,35 @@ const STATUS_LABELS: Record<string, string> = {
   interrupted: "Interrupted",
 };
 
+/**
+ * What the status band says. A parked run is still `running` on the wire -
+ * correctly, since the run owns its slot and Stop still applies - but
+ * "Working…" is the wrong thing to tell someone whose answer is the only
+ * reason it is not working. Nothing is happening until they act, and the
+ * one line they are already watching should be what says so.
+ */
+function statusLabel(data: HarnessNodeData): string {
+  if (data.harnessStatus === "running") {
+    if (data.harnessAwaitingApproval) return "Waiting for your approval";
+    if (data.harnessAwaitingQuestion) return "Waiting for your answer";
+  }
+  return STATUS_LABELS[data.harnessStatus] ?? data.harnessStatus;
+}
+
+/** Parked reads as a warning, not as progress - the same semantic the
+ * approval panel's own border already uses. */
+function statusClass(data: HarnessNodeData): string {
+  const parked = data.harnessAwaitingApproval || data.harnessAwaitingQuestion;
+  return parked && data.harnessStatus === "running"
+    ? "harness-node-status-waiting"
+    : `harness-node-status-${data.harnessStatus}`;
+}
+
+// A run binds its root once, at the start, and every tool in it is
+// confined to that root - so rebinding mid-run is not a thing that can
+// mean anything. The controls say that rather than being inertly grey.
+const WORKSPACE_LOCKED_HINT = "The workspace is fixed while the agent is working - stop it first";
+
 // Every non-running status accepts a follow-up: the transcript is the
 // resume point, so done/failed/stopped/interrupted/idle all continue the
 // same conversation (intents_harness.send refuses only a busy node).
@@ -149,6 +178,20 @@ function HarnessNodeViewInner({ data, selected }: NodeProps<HarnessFlowNode>) {
       denyButtonRef.current?.focus();
     }
   }, [data.harnessAwaitingApproval, collapsed]);
+
+  // "What is it doing?" is the question a running agent raises, and the
+  // answer was one click away behind a closed <details>. Opened once, on
+  // the first activity of a run - once only, so a deliberate collapse
+  // stays collapsed for the rest of that run instead of springing back
+  // open on the next tool call.
+  const autoOpenedForRun = useRef<string | null>(null);
+  useEffect(() => {
+    const details = activityDetailsRef.current;
+    if (!details || !running || data.harnessActivity.length === 0) return;
+    if (autoOpenedForRun.current === data.harnessRunId) return;
+    autoOpenedForRun.current = data.harnessRunId;
+    details.open = true;
+  }, [data.harnessActivity.length, data.harnessRunId, running]);
 
   // Same follow-the-log behavior as PlanNodeView's activity list: pinned
   // to the newest row only while running and only while open.
@@ -201,9 +244,7 @@ function HarnessNodeViewInner({ data, selected }: NodeProps<HarnessFlowNode>) {
         )
       }
     >
-      <div className={`plan-node-status harness-node-status-${data.harnessStatus}`}>
-        {STATUS_LABELS[data.harnessStatus] ?? data.harnessStatus}
-      </div>
+      <div className={`plan-node-status ${statusClass(data)}`}>{statusLabel(data)}</div>
       {data.harnessStatusDetail && (
         <p className="plan-node-detail" role={data.harnessStatus === "failed" ? "alert" : undefined}>
           {data.harnessStatusDetail}
@@ -235,6 +276,7 @@ function HarnessNodeViewInner({ data, selected }: NodeProps<HarnessFlowNode>) {
               className="plan-node-button nodrag"
               onClick={data.onUseScratch}
               disabled={running}
+              title={running ? WORKSPACE_LOCKED_HINT : undefined}
             >
               Use scratch
             </button>
@@ -247,6 +289,7 @@ function HarnessNodeViewInner({ data, selected }: NodeProps<HarnessFlowNode>) {
               className="plan-node-button nodrag"
               onClick={data.onPickWorkspace}
               disabled={running}
+              title={running ? WORKSPACE_LOCKED_HINT : undefined}
             >
               Choose folder…
             </button>

--- a/web_ui/src/app/chrome/HarnessLaunchDialog.test.tsx
+++ b/web_ui/src/app/chrome/HarnessLaunchDialog.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * The agent launcher. Same scaffolding as BuilderLaunchDialog.test.tsx (its
+ * sibling and the shape this dialog was built from): OverlayProvider +
+ * ReactFlowProvider, a button that opens the overlay, and
+ * makeRequestOnlyTransport for the intent call-shape assertions.
+ *
+ * The cases here are the launch-time friction ones - choosing a workspace
+ * before the first run, and Enter submitting the way the agent card's own
+ * composer does - since binding a folder afterwards meant the first run of
+ * every real piece of work was spent in scratch and then repeated.
+ */
+import { ReactFlowProvider } from "@xyflow/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import type { SceneStore } from "../canvas/sceneStore";
+import { HarnessLaunchDialog } from "./HarnessLaunchDialog";
+import { OverlayProvider, useOverlays } from "../overlays/overlays";
+import { makeRequestOnlyTransport as makeTransport } from "../../lib/ws/transport.testUtils";
+
+function makeStore() {
+  return { getScene: () => ({ nodes: [] }) } as unknown as SceneStore;
+}
+
+function OpenAgentButton() {
+  const overlays = useOverlays();
+  return (
+    <button type="button" onClick={() => overlays.open("harness-launch", "dialog")}>
+      open agent
+    </button>
+  );
+}
+
+async function setup(picked: unknown = "C:\\projects\\thing") {
+  const user = userEvent.setup();
+  const fake = makeTransport();
+  fake.request.mockImplementation((_topic: string, intent: string) =>
+    intent === "pickLaunchWorkspace" ? Promise.resolve(picked) : Promise.resolve("n7"),
+  );
+  render(
+    <OverlayProvider>
+      <ReactFlowProvider>
+        <OpenAgentButton />
+        <HarnessLaunchDialog transport={fake.transport} store={makeStore()} />
+      </ReactFlowProvider>
+    </OverlayProvider>,
+  );
+  await user.click(screen.getByRole("button", { name: "open agent" }));
+  return { user, ...fake };
+}
+
+describe("HarnessLaunchDialog", () => {
+  it("starts in scratch when no folder is chosen", async () => {
+    const { user, intents } = await setup();
+
+    await user.type(screen.getByLabelText(/what should the agent work on/i), "summarize the repo");
+    await user.click(screen.getByRole("button", { name: "Start the agent" }));
+
+    expect(intents).toContainEqual(["harness", "start", ["summarize the repo", 16, ""]]);
+  });
+
+  it("carries a chosen folder into the very first run", async () => {
+    const { user, intents } = await setup();
+
+    await user.type(screen.getByLabelText(/what should the agent work on/i), "fix the failing test");
+    await user.click(screen.getByRole("button", { name: "Choose folder…" }));
+    expect(await screen.findByText("C:\\projects\\thing")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Start the agent" }));
+
+    expect(intents).toContainEqual([
+      "harness", "start", ["fix the failing test", 16, "C:\\projects\\thing"],
+    ]);
+  });
+
+  it("a cancelled picker leaves the launch in scratch", async () => {
+    const { user, intents } = await setup(null);
+
+    await user.type(screen.getByLabelText(/what should the agent work on/i), "look around");
+    await user.click(screen.getByRole("button", { name: "Choose folder…" }));
+    // Still scratch: a dismissed picker chose nothing, so nothing changed.
+    expect(screen.getByText("Private scratch folder")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Start the agent" }));
+    expect(intents).toContainEqual(["harness", "start", ["look around", 16, ""]]);
+  });
+
+  it("Enter submits and Shift+Enter does not - the card composer's contract", async () => {
+    const { user, intents } = await setup();
+    const task = screen.getByLabelText(/what should the agent work on/i);
+
+    await user.type(task, "first line{Shift>}{Enter}{/Shift}second line");
+    expect(intents.filter(([, intent]) => intent === "start")).toHaveLength(0);
+
+    await user.type(task, "{Enter}");
+    expect(intents).toContainEqual([
+      "harness", "start", ["first line\nsecond line", 16, ""],
+    ]);
+  });
+
+  it("describes what the agent can actually do, approvals included", async () => {
+    // The hint is the only thing anyone reads before granting the first
+    // tool call, so it has to name the real capability surface - it used to
+    // say "read-only file tools" about an agent that writes files and runs
+    // shell commands.
+    await setup();
+    const hint = screen.getByText(/reads and writes files/i);
+    expect(hint).toHaveTextContent(/shell and Python/i);
+    expect(hint).toHaveTextContent(/asks before anything that changes your machine/i);
+  });
+});

--- a/web_ui/src/app/chrome/HarnessLaunchDialog.tsx
+++ b/web_ui/src/app/chrome/HarnessLaunchDialog.tsx
@@ -14,8 +14,16 @@ import { Dialog, useOverlays } from "../overlays/overlays";
  * center is approximate).
  *
  * Deliberately smaller than the Builder's launcher: no recipes, no
- * oversight modes (H1 runs read-only tools under a fixed grant - there is
- * nothing to choose an oversight level ABOUT yet), one budget number.
+ * oversight modes (the grant set is fixed and every mutating tool asks
+ * for approval individually, so there is no oversight LEVEL to choose),
+ * one budget number and one workspace choice.
+ *
+ * The workspace is chosen HERE rather than only on the node afterwards:
+ * binding a folder after the fact meant letting a scratch run finish,
+ * rebinding, and re-sending the same task, so the first run of every
+ * real piece of work was wasted. The pick itself is the grant (the
+ * backend adds the folder to the trust list when the picker returns),
+ * and the run re-checks that list when it binds.
  */
 
 const DEFAULT_MAX_TURNS = 16;
@@ -34,9 +42,23 @@ export function HarnessLaunchDialog({ transport, store }: { transport: WsTranspo
   const reactFlow = useReactFlow();
   const [task, setTask] = useState("");
   const [maxTurns, setMaxTurns] = useState<number>(DEFAULT_MAX_TURNS);
+  const [workspace, setWorkspace] = useState("");
+  const [picking, setPicking] = useState(false);
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const latestRequestId = useRef(0);
+
+  function pickWorkspace() {
+    if (picking || starting) return;
+    setPicking(true);
+    transport
+      .request("harness", "pickLaunchWorkspace", [])
+      .then((folder) => {
+        if (typeof folder === "string" && folder) setWorkspace(folder);
+      })
+      .catch(() => setError("Could not open the folder picker."))
+      .finally(() => setPicking(false));
+  }
 
   function startAgent() {
     const trimmed = task.trim();
@@ -45,11 +67,12 @@ export function HarnessLaunchDialog({ transport, store }: { transport: WsTranspo
     setStarting(true);
     setError(null);
     transport
-      .request("harness", "start", [trimmed, maxTurns])
+      .request("harness", "start", [trimmed, maxTurns, workspace])
       .then((nodeId) => {
         if (requestId !== latestRequestId.current) return;
         if (nodeId != null) {
           setTask("");
+          setWorkspace("");
           overlays.close();
           const node = store.getScene().nodes.find((n) => n.id === nodeId);
           if (node) {
@@ -80,13 +103,54 @@ export function HarnessLaunchDialog({ transport, store }: { transport: WsTranspo
           placeholder="e.g. Read the files in the workspace and summarize what they contain"
           value={task}
           onChange={(event) => setTask(event.target.value)}
+          onKeyDown={(event) => {
+            // Enter sends, Shift+Enter breaks the line - the same contract
+            // the agent card's own follow-up composer uses, so the habit
+            // formed in one place works in the other.
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              startAgent();
+            }
+          }}
           rows={3}
         />
         <p className="builder-launch-hint">
-          The agent works in its own private scratch workspace with read-only
-          file tools and knowledge search, and replies on the canvas.
+          The agent reads and writes files in its workspace, runs shell and
+          Python there, and searches your knowledge. It asks before anything
+          that changes your machine, and replies on the canvas.
         </p>
       </div>
+
+      <fieldset className="builder-launch-fieldset">
+        <legend>Workspace</legend>
+        <p className="builder-launch-hint">
+          Where the agent works. A private scratch folder unless you choose
+          one of your own - choosing it here is what grants access to it.
+        </p>
+        <div className="harness-launch-workspace">
+          <span className="harness-launch-workspace-dir" title={workspace || undefined}>
+            {workspace || "Private scratch folder"}
+          </span>
+          <button
+            type="button"
+            className="builder-launch-secondary"
+            onClick={pickWorkspace}
+            disabled={picking || starting}
+          >
+            {picking ? "Choosing…" : "Choose folder…"}
+          </button>
+          {workspace && (
+            <button
+              type="button"
+              className="builder-launch-secondary"
+              onClick={() => setWorkspace("")}
+              disabled={starting}
+            >
+              Use scratch
+            </button>
+          )}
+        </div>
+      </fieldset>
 
       <fieldset className="builder-launch-fieldset">
         <legend>Budget</legend>

--- a/web_ui/src/app/chrome/commands.ts
+++ b/web_ui/src/app/chrome/commands.ts
@@ -220,6 +220,17 @@ export function buildCommands(
       enabled: () => true,
     },
     {
+      // ADR-012's "register every new surface in the palette" rule - the
+      // agent launcher was reachable only by clicking its AppBar icon,
+      // while every sibling dialog here has had a palette twin since it
+      // shipped.
+      id: "open-agent",
+      name: "Open Agent",
+      aliases: ["workspace agent", "harness", "new agent"],
+      run: () => overlays.open("harness-launch", "dialog"),
+      enabled: () => true,
+    },
+    {
       id: "open-plugins",
       name: "Open Plugins",
       aliases: ["plugin picker", "add node"],

--- a/web_ui/src/app/chrome/help-data/sections.ts
+++ b/web_ui/src/app/chrome/help-data/sections.ts
@@ -374,6 +374,54 @@ export const HELP_SECTIONS: HelpSection[] = [
     ]
   },
   {
+    "name": "Agent",
+    "description": "An agent that works inside a folder - reading, writing, running commands - over as many steps as the task needs, and answers on the canvas.",
+    "subsections": [
+      {
+        "title": "Starting One",
+        "items": [
+          {
+            "action": "Task and Workspace",
+            "description": "Open Agent, describe the task, and choose the folder it should work in. Choosing the folder in the launcher is what grants access to it - pick nothing and the agent gets a private scratch folder of its own instead."
+          },
+          {
+            "action": "What It Can Do",
+            "description": "Read, write, and search files in its workspace; run shell commands and Python there; keep long-running processes open; search your knowledge base; delegate read-only lookups to subagents; and build on the canvas it lives in."
+          },
+          {
+            "action": "Turn Budget",
+            "description": "Max turns is a hard limit on model turns for one task. Hitting it stops the task with everything it did intact - send a follow-up to continue from there."
+          },
+          {
+            "action": "AGENTS.md",
+            "description": "A file named AGENTS.md at the workspace root joins the agent's instructions, so a folder can carry its own conventions. It is reference material only: it cannot grant a capability or waive an approval."
+          }
+        ]
+      },
+      {
+        "title": "Working With One",
+        "items": [
+          {
+            "action": "Approvals",
+            "description": "Anything that changes your machine asks first, showing the exact command or file content. Approve once, or allow that tool for the rest of the session - except for commands that cannot be undone, which always ask again."
+          },
+          {
+            "action": "Watch It Work",
+            "description": "The card shows a live checklist when the agent keeps one, an activity log of every tool call, and how much of its context budget the conversation fills. When it needs you, the status says so."
+          },
+          {
+            "action": "Answer, Follow Up, and Stop",
+            "description": "The agent can stop and ask you a question mid-run. Once a task ends - done, stopped, or failed - send a follow-up to keep the same conversation going; its history lives with its workspace, so it survives a restart."
+          },
+          {
+            "action": "The Agent vs. the Builder",
+            "description": "The Builder constructs nodes on the canvas from a plan you approve. The Agent works in a real folder on disk and reports back. Reach for the Agent when the work is files and commands, not canvas structure."
+          }
+        ]
+      }
+    ]
+  },
+  {
     "name": "Settings & Models",
     "description": "How runtime modes, providers, model routing, and quality-of-life settings shape the behavior of the application.",
     "subsections": [

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -7488,6 +7488,9 @@ mark.document-view-search-match-current {
 .harness-node-status-failed { color: var(--gl-semantic-status-error); }
 .harness-node-status-done { color: var(--gl-semantic-status-success); }
 .harness-node-status-interrupted { color: var(--gl-semantic-status-warning); }
+/* Parked on a human: the same warning token the approval panel's own
+   border uses, so "this is on you now" reads the same in both places. */
+.harness-node-status-waiting { color: var(--gl-semantic-status-warning); }
 .harness-node-reply {
   font-size: 12px;
   line-height: 1.5;
@@ -7632,7 +7635,12 @@ mark.document-view-search-match-current {
   flex-direction: column;
   gap: 3px;
 }
-.builder-launch-delete-recipe {
+/* One small-secondary-button idiom for this dialog family, two names: the
+   recipe delete (destructive, red on hover) and the neutral secondary the
+   workspace row uses. Shared declarations rather than a second lookalike
+   block, so the two can never drift into two slightly different buttons. */
+.builder-launch-delete-recipe,
+.builder-launch-secondary {
   align-self: flex-start;
   font-size: 11px;
   font-family: inherit;
@@ -7647,7 +7655,30 @@ mark.document-view-search-match-current {
   color: var(--gl-semantic-status-error);
   border-color: var(--gl-semantic-status-error);
 }
-.builder-launch-delete-recipe:disabled { opacity: 0.5; cursor: default; }
+.builder-launch-secondary:hover:not(:disabled) {
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-hover);
+}
+.builder-launch-delete-recipe:disabled,
+.builder-launch-secondary:disabled { opacity: 0.5; cursor: default; }
+
+/* The launcher's workspace row - same "path, ellipsized, with its buttons
+   beside it" shape as the agent card's own .harness-node-workspace, at the
+   dialog's type size rather than the node's. */
+.harness-launch-workspace {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.harness-launch-workspace-dir {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--gl-surface-text-primary);
+}
 
 /* Same disclosure posture as .plan-node-activity/.chat-node-tool-invocations
    - a native <details>, cursor-pointer bold summary - here hiding the exact

--- a/web_ui/vitest.setup.ts
+++ b/web_ui/vitest.setup.ts
@@ -38,6 +38,16 @@ if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {};
 }
 
+// Same gap, same posture: jsdom implements no Element.scrollTo either, so a
+// follow-the-log effect (PlanNodeView/HarnessNodeView pin their activity
+// list to the newest row) throws the moment a test actually renders with
+// that list open. It never did before the agent card started opening its own
+// activity log, which is exactly the kind of "worked only because the branch
+// was unreachable" gap a stub here closes for good.
+if (!Element.prototype.scrollTo) {
+  Element.prototype.scrollTo = () => {};
+}
+
 // ADR-012 stage 12.4: jsdom implements no window.matchMedia at all (not even
 // a no-op stub) - reducedMotion.ts's own prefersReducedMotion() throws
 // "matchMedia is not a function" in any test that exercises a component


### PR DESCRIPTION
## Problem

A UX pass over the agent (harness) node and its launcher. Five things stood between someone and a working agent.

**The launcher described the wrong product.** Its hint read "works in its own private scratch workspace with read-only file tools and knowledge search" — written for H1 and never revised. The agent writes files, runs shell commands and Python, holds long-running processes open, spawns subagents, and builds on the canvas. That hint is the only thing anyone reads before granting the first tool call, so it was actively misinforming the one decision that matters.

**The workspace could only be chosen after the fact.** The folder picker lived on the node and was disabled mid-run, so working in a real project folder meant: launch → let a scratch run finish → rebind → re-send the same task. The first run of every real piece of work was spent in the wrong place.

**A run parked on a human still said "Working…".** A run awaiting approval or an answer is `running` on the wire — correctly — but the status band is the line someone watches, and it claimed progress at exactly the moment nothing could happen without them.

**"What is it doing?" was one click away** behind a closed disclosure that nobody thinks to open.

**The launcher was reachable only by clicking its AppBar icon**, and the Help dialog documented the Builder in depth while saying nothing about the Agent at all.

## Change

- `chrome/HarnessLaunchDialog.tsx` — hint names the real capability surface and the approval gate; a Workspace fieldset picks the folder before launch; Enter submits (Shift+Enter breaks the line), matching the card's own composer.
- `api/intents_harness.py` — `harness/pickLaunchWorkspace`, the node-less sibling of the existing pick, sharing one picker-and-grant helper with it; `harness/start` accepts the chosen path. **No new trust surface**: the pick is still the consent, and `bound_root` re-checks the trust list when the run binds, so a path arriving any other way still degrades to scratch.
- `canvas/HarnessNodeView.tsx` — status band reads "Waiting for your approval" / "Waiting for your answer" in the approval panel's own warning color; the activity log opens on a run's first tool call, once, so a deliberate collapse sticks; the workspace buttons say why they are inert mid-run.
- `chrome/commands.ts` — the agent launcher joins the command palette (ADR-012's "register every new surface in the palette" rule; every sibling dialog already had a twin there).
- `chrome/help-data/sections.ts` — an Agent section covering task/workspace, what it can do, the turn budget, `AGENTS.md`, approvals, and when to reach for it over the Builder.
- `vitest.setup.ts` — a no-op `Element.scrollTo`, same posture as the `scrollIntoView` stub beside it: the follow-the-log effect never ran in jsdom until the activity log started opening itself, so the missing API had gone unnoticed.
- `tests/test_undo_classification_gate.py`, `tests/undo_classification.py` — the new intent classified `"B"` (run-config, touches no document content) and the locked intent count moved 178 → 179, as that gate requires for a deliberate change.

## Test plan

- `cd web_ui && npm run check` — 2045 vitest tests across 86 files, typecheck, lint, build, bundle check: all pass. 9 new tests: 5 for the launcher (scratch default, folder carried into the first run, cancelled picker, Enter vs Shift+Enter, the corrected hint) and 4 for the card (parked status in both flavors, still-working when it really is, activity auto-open, and that it does not spring back open after a collapse).
- `python -m pytest -q backend/tests/test_harness_user_dirs.py tests/test_undo_classification_gate.py` — 15 passed. 4 new backend tests: the launcher's folder binds before the first run, a launcher path is a request and not a grant, the pick grants and answers with the path, and a cancelled picker grants nothing.
- `ruff` and `mypy` clean.
- The launcher and the palette entry were verified in the running app; the parked-status and activity-open states are covered by component tests rather than a live run.
