### PR TITLE
Rebuild the application bar

### DIFF
--- a/web_ui/src/app/chrome/AppBar.test.tsx
+++ b/web_ui/src/app/chrome/AppBar.test.tsx
@@ -9,15 +9,27 @@ import type { WsTransport } from "../../lib/ws/transport";
 
 // R8a (UI/UX issue list findings #5 and #8): this is the first dedicated
 // test file for AppBar.tsx. jsdom does not implement CSS @container queries
-// (or any layout at all), so it cannot verify the RESPONSIVE half of finding
-// #5's fix - which of the two copies of a button is actually visible at a
-// given width is a live-browser-only concern, verified separately. What
+// (or any layout at all), so it cannot verify the WIDTH half of finding #5's
+// fix - which of the two copies of a button is actually visible once the bar
+// has folded is a live-browser-only concern, verified separately. What
 // these tests cover instead: the dead provider-mode <select> from finding #8
 // is genuinely gone; every real button (both the inline copy and its
 // overflow-menu duplicate) is present and calls the correct handler; the
-// overflow menu opens/closes correctly; and every duplicated pair carries
-// the same data-tier value, since a mismatch there would silently break the
-// CSS wiring in a way no visual glance at one window size would catch.
+// overflow menu opens/closes correctly; and the two sets stay in step -
+// every collapsible action has a duplicate and every non-collapsible one
+// does not, which is the invariant that silently breaks the CSS wiring in a
+// way no visual glance at one window size would catch.
+//
+// The toolbar redesign added three more contracts worth pinning here,
+// because each is a behavioural claim rather than a visual one:
+//   - Help/Diagnostics/About moved off the bar into a Help MENU, so the
+//     bar must no longer expose them as top-level buttons, and the menu
+//     must actually reach all three;
+//   - the zoom control is a live readout whose accessible name still says
+//     what clicking it does, not just what it currently shows;
+//   - keyboard hints live in `title` and nowhere else - putting them in the
+//     accessible name would make a screen reader recite "Undo Ctrl+Z" and
+//     would break every by-name query in this file.
 
 function makeStore(): SceneStore {
   // ADR-003 stage 3.1: fireIntent is the transport method SceneStore's own
@@ -46,15 +58,17 @@ describe("AppBar", () => {
     expect(screen.queryByTitle("Switching provider modes isn't available yet")).toBeNull();
   });
 
-  it("Library, Save and Settings are present as plain toolbar buttons (the tier that never collapses)", () => {
+  it("Library, Save and Settings are present as plain toolbar buttons (the three that never collapse)", () => {
     renderAppBar();
     expect(screen.getByRole("button", { name: "Library" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
-    // None of the three ever has a data-tier - confirmed by absence, not a
-    // positive class check, since "never collapses" IS "has no tier".
+    // None of the three sits in a collapsible group - confirmed by absence
+    // of the marker class, since "never collapses" IS "has no .appbar-tier".
     for (const label of ["Library", "Save", "Settings"]) {
-      expect(screen.getByRole("button", { name: label })).not.toHaveAttribute("data-tier");
+      expect(
+        screen.getByRole("button", { name: label }).closest(".appbar-group")?.className,
+      ).not.toContain("appbar-tier");
     }
   });
 
@@ -163,16 +177,18 @@ describe("AppBar", () => {
       expect(organizeSpy).toHaveBeenCalledOnce();
     });
 
-    it("clicking an overlay-opening item (About) opens that overlay and closes the menu", async () => {
+    it("clicking an overlay-opening item (Pins) opens that overlay and closes the menu", async () => {
       const user = userEvent.setup();
       renderAppBar();
       await user.click(screen.getByRole("button", { name: "More toolbar actions" }));
-      await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "About" }));
+      await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Pins" }));
 
       expect(screen.queryByRole("dialog")).toBeNull();
-      // The inline About chip (still in the DOM, jsdom does not evaluate
-      // the CSS that would visually hide it) now reads real open state.
-      expect(screen.getByRole("button", { name: "About" }).className).toContain("checked");
+      // The inline Pins chip (still in the DOM, jsdom does not evaluate the
+      // CSS that would visually hide it) now reads real open state. Pins
+      // rather than About because About no longer HAS an inline copy - see
+      // the Help menu block below.
+      expect(screen.getByRole("button", { name: "Pins" }).className).toContain("checked");
     });
 
     it("the six overlay-opening overflow items (Pins/View/Plugins/About/Help/Diagnostics) carry aria-pressed, matching their inline copies' real-state contract", async () => {
@@ -191,54 +207,158 @@ describe("AppBar", () => {
       }
     });
 
-    it("every overflow-menu item shares its data-tier with the matching inline button, and only the always-visible three (Library/Save/Settings) have no overflow duplicate at all", async () => {
+    it("the overflow menu holds a copy of every collapsible action and of nothing else", async () => {
       const user = userEvent.setup();
       renderAppBar();
       await user.click(screen.getByRole("button", { name: "More toolbar actions" }));
-      const menu = screen.getByRole("dialog");
+      const menu = screen.getByRole("dialog", { name: "More toolbar actions" });
 
-      // Tiers live on the GROUP wrapper, not the individual button: the
-      // bar collapses whole clusters so related actions stay together at
-      // every width instead of leaving fragments behind (see AppBar.tsx).
-      // The contract this pins is unchanged though - an inline action and
-      // its overflow duplicate must always collapse at the same tier.
-      const pairs: [string, string][] = [
-        ["Undo", "1"],
-        ["Redo", "1"],
-        ["Zoom In", "1"],
-        ["Zoom Out", "1"],
-        ["Reset", "1"],
-        ["Fit All", "1"],
-        ["Organize", "2"],
-        ["Pins", "2"],
-        ["Export PNG", "2"],
-        ["View", "3"],
-        ["Plugins", "3"],
-        ["Global Search", "4"],
-        ["Knowledge", "4"],
-        ["Builder", "4"],
-        ["Diagnostics", "4"],
-        ["Help", "4"],
-        ["About", "4"],
+      // Groups collapse whole and all at once, so an inline action and its
+      // menu copy have to appear and disappear together (styles.css, the
+      // single @container rule). Matched by substring rather than exact
+      // string because one pair deliberately differs: the inline zoom
+      // control is a live readout named "Reset zoom to 100%" while its menu
+      // copy is plain "Reset". Disambiguating the two hits by DOM position
+      // rather than by string stays correct for every label uniformly
+      // instead of special-casing the one that needs it.
+      const collapsible = [
+        "Undo",
+        "Redo",
+        "Zoom In",
+        "Zoom Out",
+        "Reset",
+        "Fit All",
+        "Organize",
+        "Pins",
+        "Export PNG",
+        "View",
+        "Plugins",
+        "Global Search",
+        "Knowledge",
+        "Builder",
+        "Agent",
       ];
-      for (const [label, tier] of pairs) {
-        // Every duplicated pair shares its exact label except Plugins (the
-        // inline button's accessible name includes its chevron span,
-        // "Plugins ▼", while its overflow duplicate is plain "Plugins" - a
-        // real, intentional difference, see AppBar.tsx) - so match by
-        // substring, then disambiguate the two hits by DOM position rather
-        // than by string, which stays correct for every label uniformly
-        // rather than special-casing the one that needs it.
+      for (const label of collapsible) {
         const matches = screen.getAllByRole("button", { name: new RegExp(label) });
         const inline = matches.find((el) => !menu.contains(el));
-        const overflowItem = matches.find((el) => menu.contains(el));
-        expect(inline?.closest(".appbar-group")).toHaveAttribute("data-tier", tier);
-        expect(overflowItem).toHaveAttribute("data-tier", tier);
+        const copy = matches.find((el) => menu.contains(el));
+        expect(inline, `${label} has no inline copy`).toBeDefined();
+        expect(copy, `${label} has no overflow copy`).toBeDefined();
+        // The inline copy always sits in a group that CAN collapse.
+        expect(inline?.closest(".appbar-group")?.className).toContain("appbar-tier");
       }
 
+      // Help/Diagnostics/About have no inline copy at all any more - they
+      // are reached from the Help menu at a normal desktop width. They still
+      // need their own entry here, because the tools cluster that hosts that
+      // menu is itself collapsible.
+      for (const label of ["Diagnostics", "Help", "About"]) {
+        expect(within(menu).getByRole("button", { name: label })).toBeInTheDocument();
+      }
+
+      // The three controls that never collapse have no duplicate, and their
+      // groups carry no .appbar-tier for the CSS to act on.
       for (const label of ["Library", "Save", "Settings"]) {
         expect(within(menu).queryByRole("button", { name: label })).toBeNull();
+        expect(
+          screen.getByRole("button", { name: label }).closest(".appbar-group")?.className,
+        ).not.toContain("appbar-tier");
       }
+    });
+  });
+  // -- Toolbar redesign ----------------------------------------------------
+
+  describe("Help menu", () => {
+    it("Help, Diagnostics and About are no longer top-level toolbar buttons", () => {
+      renderAppBar();
+      for (const label of ["Help", "Diagnostics", "About"]) {
+        expect(screen.queryByRole("button", { name: label })).toBeNull();
+      }
+      // The one control that replaced all three. Icon-only, so its
+      // accessible name has to come from aria-label or it is nameless.
+      expect(screen.getByRole("button", { name: "Help and diagnostics" })).toBeInTheDocument();
+    });
+
+    it("opens a menu that reaches all three destinations", async () => {
+      const user = userEvent.setup();
+      renderAppBar();
+      const trigger = screen.getByRole("button", { name: "Help and diagnostics" });
+      expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+      const menu = within(screen.getByRole("dialog", { name: "Help and diagnostics" }));
+      for (const label of ["Help", "Diagnostics", "About"]) {
+        expect(menu.getByRole("button", { name: label })).toBeInTheDocument();
+      }
+    });
+
+    it("choosing a destination replaces the menu with that surface", async () => {
+      const user = userEvent.setup();
+      renderAppBar();
+      await user.click(screen.getByRole("button", { name: "Help and diagnostics" }));
+      await user.click(
+        within(screen.getByRole("dialog", { name: "Help and diagnostics" })).getByRole("button", {
+          name: "About",
+        }),
+      );
+      // OverlayProvider is single-open: opening "about" IS what closes this
+      // menu, so an assertion that the menu is gone is the observable proof
+      // the item dispatched - AppBar does not render AboutDialog itself.
+      expect(screen.queryByRole("dialog", { name: "Help and diagnostics" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Help and diagnostics" })).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+    });
+
+    it("the trigger reads real open state, like every other chip on the bar", async () => {
+      const user = userEvent.setup();
+      renderAppBar();
+      const trigger = screen.getByRole("button", { name: "Help and diagnostics" });
+      expect(trigger.className).not.toContain("checked");
+      await user.click(trigger);
+      expect(trigger.className).toContain("checked");
+      await user.click(trigger);
+      expect(trigger.className).not.toContain("checked");
+    });
+  });
+
+  describe("zoom readout", () => {
+    it("shows the live zoom level and names its action, not its value", () => {
+      renderAppBar();
+      // React Flow's default transform is [0, 0, 1] before any viewport
+      // interaction, so 100% is the honest initial reading here.
+      const zoom = screen.getByRole("button", { name: "Reset zoom to 100%" });
+      expect(zoom).toHaveTextContent("100%");
+      // The accessible name is the ACTION. A control named "100%" would
+      // announce its current state and never say what activating it does.
+      expect(zoom).toHaveAttribute("aria-label", "Reset zoom to 100%");
+    });
+
+    it("replaced the concentric-circles reset icon rather than adding to it", () => {
+      renderAppBar();
+      // Exactly one inline control resets the zoom; the other "Reset" in the
+      // DOM belongs to the overflow menu, which is closed here.
+      expect(screen.getAllByRole("button", { name: /Reset/ })).toHaveLength(1);
+    });
+  });
+
+  describe("keyboard hints", () => {
+    // Hints belong in the tooltip and nowhere else: an aria-label of
+    // "Undo (Ctrl+Z)" makes a screen reader recite the binding on every
+    // focus, and would break every by-name query in this file.
+    it.each([
+      ["Library", "Library (Ctrl+L)"],
+      ["Save", "Save (Ctrl+S)"],
+      ["Undo", "Undo (Ctrl+Z)"],
+      ["Redo", "Redo (Ctrl+Shift+Z)"],
+      ["Global Search", "Global Search (Ctrl+F)"],
+    ])("%s names its binding in the tooltip only", (name, title) => {
+      renderAppBar();
+      const button = screen.getByRole("button", { name });
+      expect(button).toHaveAttribute("title", title);
     });
   });
 });

--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -1,4 +1,4 @@
-import { useReactFlow } from "@xyflow/react";
+import { useReactFlow, useStore } from "@xyflow/react";
 import { useSyncExternalStore } from "react";
 import { FIT_VIEW_MAX_ZOOM } from "../canvas/canvasConstants";
 import { exportCanvasAsPng } from "../canvas/exportCanvasPng";
@@ -22,18 +22,58 @@ import { AppBarIcon, type AppBarIconName } from "./AppBarIcon";
  *   button instead of anchored to the window edge.
  * - The row has a FIXED height and every control a fixed height, so the bar
  *   never changes size with its contents.
- * - Related actions live in `.appbar-group` containers with uniform inner
- *   spacing and a shared surface. Grouping is what carries the visual
- *   organisation; the old bar was one undifferentiated run of twenty text
- *   buttons separated by ad-hoc 1px rules.
+ * - Related actions live in `.appbar-group` containers. Grouping is what
+ *   carries the visual organisation; the bar this replaced was one
+ *   undifferentiated run of twenty text buttons separated by ad-hoc rules.
  *
- * ICONS vs LABELS. Frequent, app-specific verbs (Library, Save, Organize,
- * View, Plugins) keep text - they are the vocabulary of the product and
- * nothing draws them unambiguously. Universally-recognised mechanics (undo,
- * redo, the four viewport controls) and the utility surfaces on the right
- * become icons with `title` + `aria-label` carrying the exact same wording
- * they had as text, which is what keeps them findable by keyboard, by
- * screen reader, and by every existing test.
+ * GROUPING, and why it is drawn the way it is. Each group used to be its
+ * own filled, bordered, padded box. Nine such boxes sat in a 44px strip, so
+ * the loudest marks in the bar were its containers rather than its
+ * controls, and a two-button cluster like Library/Save read as a segmented
+ * control - one widget with two states - rather than as two unrelated
+ * commands. Groups are flat now: 2px inside a group, 12px between groups,
+ * and a single hairline rule between adjacent groups (styles.css,
+ * `.appbar-group + .appbar-group::before`). Proximity plus one hairline is
+ * the standard toolbar-grouping treatment - PatternFly's toolbar guidance
+ * calls for exactly this once a bar carries enough items to need it - and
+ * it spends far less ink than a box per cluster.
+ *
+ * The separator is a pseudo-element on the FOLLOWING group rather than a
+ * real element between two groups, because groups collapse (see the spill
+ * guard below) and a standalone separator element would be left behind as a
+ * stray rule floating in the gap where its neighbours used to be.
+ * Attached to the group, a separator disappears exactly when the thing it
+ * separates does. `+` adjacency is DOM-based, not layout-based, so a
+ * display:none group does not break the chain for the groups after it.
+ *
+ * ICONS vs LABELS. Frequent, app-specific verbs (Library, Save, View,
+ * Plugins) keep text - they are the vocabulary of the product and nothing
+ * draws them unambiguously. Universally-recognised mechanics (undo, redo,
+ * the viewport controls) and the utility surfaces on the right are icons
+ * with `title` + `aria-label` carrying the exact same wording they had as
+ * text, which is what keeps them findable by keyboard, by screen reader,
+ * and by every existing test. Where an action has a global keybinding
+ * (shortcuts.ts) the tooltip - and ONLY the tooltip - names it; the
+ * accessible name stays the bare verb, so a screen reader announces the
+ * control rather than reciting its shortcut.
+ *
+ * ZOOM READOUT. The viewport group's middle control is the live zoom
+ * percentage, and clicking it resets to 100%. It replaces an icon button
+ * whose glyph (two concentric circles) named neither its action nor the
+ * current state - it read as a record button. Every canvas tool this app
+ * is measured against shows the zoom level as text for the same reason:
+ * the number is the one part of viewport state that cannot be inferred by
+ * looking at the canvas. It subscribes to the React Flow transform in its
+ * OWN component so a wheel-zoom re-renders one <button> rather than all
+ * twenty controls in this bar (ADR-011).
+ *
+ * HELP MENU. Help, Diagnostics and About are three low-frequency
+ * destinations that were three permanent icons in the right-hand cluster,
+ * carrying the same visual weight as Search and the Builder. They are one
+ * menu now, which is where a rarely-used destination belongs, and which
+ * takes the right-hand run of icons from seven down to five. Nothing became
+ * unreachable: each is still its own command in the palette (commands.ts,
+ * `open-help`/`open-about`) and still its own item in the overflow menu.
  *
  * Intent routing, surface by surface, against the ToolbarBridge @Slot list:
  * - zoomIn/zoomOut/resetZoom/fitAll -> React Flow viewport ops (they were
@@ -60,28 +100,36 @@ import { AppBarIcon, type AppBarIconName } from "./AppBarIcon";
  * and Settings' own per-mode pages already give that switch a home
  * co-located with the configuration it affects.
  *
- * R8a (finding #5): below a narrow width this toolbar's buttons had no
- * shrink/wrap/overflow behavior at all, so its right end ran off the window
- * edge, dragging a horizontal scrollbar across the WHOLE document with it.
- * Fixed with a real overflow menu: `.appbar` declares `container-type:
- * inline-size` (styles.css) so its descendants can query how much room THIS
- * toolbar - not the window - actually has, and whole GROUPS collapse in
- * tiers (least-used first). Collapsing by group rather than by button keeps
- * related actions together at every width instead of leaving fragments of a
- * cluster behind. Every collapsible action is rendered twice - once inline,
- * once inside the overflow menu, tagged with the same data-tier - and pure
- * CSS decides which copy is visible. No ResizeObserver or width measurement
- * anywhere; container queries are declarative and this app targets one
- * engine (WebView2).
+ * SPILL GUARD, not a responsive layout. Graphlink is desktop-only software
+ * and this bar is laid out for a desktop window; there is no mobile
+ * breakpoint ladder here and none is wanted. What there is is a single
+ * floor. R8a (finding #5): dragged narrower than its own contents, this
+ * toolbar had no shrink, wrap or overflow behaviour at all, so its right
+ * end ran off the window edge and dragged a horizontal scrollbar across the
+ * WHOLE document with it. Below one width, therefore, every group that is
+ * not Library/Save or Settings moves into an overflow menu in one step -
+ * not four graded stages, which would be a phone layout wearing a desk.
  *
- * The overflow menu is the shared `Popover` (overlays.tsx), NOT `NodeMenu`
- * (canvas/NodeMenu.tsx) - tried first, reverted after live testing caught a
- * real bug: NodeMenu portals to document.body, and a portaled element is no
- * longer a DESCENDANT of `.appbar`, so it falls OUTSIDE the `@container
- * appbar` scope entirely and every item in it would have silently stayed
- * hidden forever. `.appbar` therefore does NOT get `overflow: hidden`
- * either; the horizontal-spill backstop is the tier breakpoints being
- * correctly tuned, plus the grid track above that cannot be overrun.
+ * `.appbar` declares `container-type: inline-size` (styles.css) so the rule
+ * measures how much room THIS toolbar has rather than how wide the window
+ * is, which is the honest question given the brand and status regions
+ * either side of it. Whole GROUPS move, never individual buttons, so a
+ * cluster is never left as a fragment of itself. Every collapsible action
+ * is rendered twice - once inline, once in the overflow menu - and pure CSS
+ * picks the visible copy. No ResizeObserver and no width measurement
+ * anywhere.
+ *
+ * The overflow menu is the shared `Popover` (overlays.tsx) in its
+ * NON-anchored form, unlike the Help menu right next to it, and that
+ * difference is forced rather than chosen: an anchored Popover portals to
+ * document.body, and a portaled element is no longer a DESCENDANT of
+ * `.appbar`, so it falls OUTSIDE the `@container appbar` scope entirely and
+ * every gated item in it would silently stay hidden forever. The Help menu
+ * has no gated contents, so it takes the anchored form and gets the
+ * viewport flip/clamp every other anchored popover gets. `.appbar`
+ * therefore does NOT get `overflow: hidden` either; the horizontal-spill
+ * backstop is that one breakpoint, plus the grid track above it that cannot
+ * be overrun.
  *
  * Both copies of a collapsible action call the exact same handler - the
  * handler is the single source of truth for BEHAVIOR, only the label markup
@@ -92,7 +140,7 @@ import { AppBarIcon, type AppBarIconName } from "./AppBarIcon";
 function BarButton({
   label,
   className,
-  title,
+  hint,
   disabled,
   trigger,
   pressed,
@@ -100,7 +148,8 @@ function BarButton({
 }: {
   label: string;
   className: string;
-  title?: string;
+  /** Keybinding, shown in the tooltip only - never in the accessible name. */
+  hint?: string;
   disabled?: boolean;
   trigger?: string;
   pressed?: boolean;
@@ -110,7 +159,7 @@ function BarButton({
     <button
       type="button"
       className={className}
-      title={title}
+      title={hint ? `${label} (${hint})` : undefined}
       disabled={disabled}
       data-overlay-trigger={trigger}
       aria-pressed={pressed}
@@ -122,7 +171,7 @@ function BarButton({
 }
 
 /**
- * Icon button. `label` is the accessible name AND the tooltip, so an
+ * Icon button. `label` is the accessible name AND the base tooltip, so an
  * icon-only control is never nameless - it reads identically to the text
  * button it replaced for anything that is not a pair of eyes.
  */
@@ -130,6 +179,7 @@ function BarIconButton({
   icon,
   label,
   className,
+  hint,
   disabled,
   trigger,
   pressed,
@@ -138,6 +188,7 @@ function BarIconButton({
   icon: AppBarIconName;
   label: string;
   className: string;
+  hint?: string;
   disabled?: boolean;
   trigger?: string;
   pressed?: boolean;
@@ -147,7 +198,7 @@ function BarIconButton({
     <button
       type="button"
       className={`${className} appbar-btn-icon`}
-      title={label}
+      title={hint ? `${label} (${hint})` : label}
       aria-label={label}
       disabled={disabled}
       data-overlay-trigger={trigger}
@@ -155,6 +206,75 @@ function BarIconButton({
       onClick={onClick}
     >
       <AppBarIcon name={icon} />
+    </button>
+  );
+}
+
+/**
+ * A control that opens a menu or panel rather than performing an action,
+ * and says so with a chevron. Distinct from BarButton/BarIconButton by
+ * `aria-haspopup="dialog"` + `aria-expanded` - Popover renders
+ * role="dialog", not role="menu", so those are the honest values.
+ */
+function BarMenuButton({
+  label,
+  icon,
+  surface,
+  isOpen,
+  labelled,
+  onClick,
+}: {
+  label: string;
+  icon?: AppBarIconName;
+  surface: string;
+  isOpen: boolean;
+  /** false => icon-only, so `label` becomes the accessible name instead. */
+  labelled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={
+        "appbar-btn appbar-btn-checkable appbar-btn-menu" +
+        (labelled ? "" : " appbar-btn-icon") +
+        (isOpen ? " checked" : "")
+      }
+      title={label}
+      aria-label={labelled ? undefined : label}
+      data-overlay-trigger={surface}
+      aria-haspopup="dialog"
+      aria-expanded={isOpen}
+      onClick={onClick}
+    >
+      {icon && <AppBarIcon name={icon} />}
+      {labelled ? label : null}
+      <AppBarIcon name="chevron" />
+    </button>
+  );
+}
+
+/**
+ * The live zoom readout and the reset-to-100% control, in one.
+ *
+ * Its own component purely so the transform subscription is scoped: a
+ * wheel-zoom pushes a new transform every animation frame, and reading it
+ * in AppBar itself would re-render the whole bar at that rate for a
+ * three-character label - ADR-011's entire subject. Tabular figures and a
+ * fixed min-width (styles.css) keep the controls either side of it from
+ * shifting as the number changes width.
+ */
+function ZoomLevelButton({ onReset }: { onReset: () => void }) {
+  const zoom = useStore((s) => s.transform[2]);
+  return (
+    <button
+      type="button"
+      className="appbar-btn appbar-btn-zoom"
+      title="Reset zoom to 100%"
+      aria-label="Reset zoom to 100%"
+      onClick={onReset}
+    >
+      {Math.round(zoom * 100)}%
     </button>
   );
 }
@@ -181,14 +301,15 @@ export function AppBar({ store }: { store: SceneStore }) {
       (value) => store.setExportInProgress(value),
     );
 
-  // Overlay-opening actions (Pins/View/Plugins/About/Help) close this popover
-  // for free via OverlayProvider's own single-open policy - opening any
+  // Overlay-opening actions (Pins/View/Plugins/About/Help) close the open
+  // menu for free via OverlayProvider's own single-open policy - opening any
   // surface replaces whatever else was open, "toolbar-overflow" included.
   // Plain actions (Organize/Zoom/Fit/Export) never touch the overlay
-  // registry at all, so their overflow copies close it explicitly.
-  const closeOverflow = () => overlays.close();
-  const overflowItem = (surface: string) =>
-    "appbar-overflow-item" + (overlays.isOpen(surface) ? " checked" : "");
+  // registry at all, so their menu copies close it explicitly.
+  const closeMenu = () => overlays.close();
+  const menuItem = (surface: string) =>
+    "appbar-menu-item" + (overlays.isOpen(surface) ? " checked" : "");
+  const overflowItem = (surface: string) => `${menuItem(surface)} appbar-overflow-item`;
 
   return (
     <div className="appbar" role="toolbar" aria-label="Application bar">
@@ -198,20 +319,27 @@ export function AppBar({ store }: { store: SceneStore }) {
       <div className="appbar-group">
         <BarButton
           label="Library"
+          hint="Ctrl+L"
           className={chip("library")}
           trigger="library"
           pressed={overlays.isOpen("library")}
           onClick={() => overlays.toggle("library", "dialog")}
         />
-        <BarButton label="Save" className="appbar-btn" onClick={() => store.saveChat()} />
+        <BarButton
+          label="Save"
+          hint="Ctrl+S"
+          className="appbar-btn"
+          onClick={() => store.saveChat()}
+        />
       </div>
 
       {/* HISTORY - keyboard equivalents exist (Ctrl+Z / Ctrl+Shift+Z), so
           this is the first group to fold away. */}
-      <div className="appbar-group appbar-tier" data-tier="1">
+      <div className="appbar-group appbar-tier">
         <BarIconButton
           icon="undo"
           label="Undo"
+          hint="Ctrl+Z"
           className="appbar-btn"
           disabled={!scene.canUndo}
           onClick={() => store.undo()}
@@ -219,6 +347,7 @@ export function AppBar({ store }: { store: SceneStore }) {
         <BarIconButton
           icon="redo"
           label="Redo"
+          hint="Ctrl+Shift+Z"
           className="appbar-btn"
           disabled={!scene.canRedo}
           onClick={() => store.redo()}
@@ -226,21 +355,22 @@ export function AppBar({ store }: { store: SceneStore }) {
       </div>
 
       {/* VIEWPORT - wheel and trackpad cover zooming, so these fold early
-          too. */}
-      <div className="appbar-group appbar-tier" data-tier="1">
+          too. Out / readout / in reads left to right as one continuous
+          scale, with Fit All after it as the "show me everything" escape. */}
+      <div className="appbar-group appbar-tier">
         <BarIconButton
           icon="zoom-out"
           label="Zoom Out"
           className="appbar-btn"
           onClick={() => zoomOut({ duration: motionDuration(150) })}
         />
+        <ZoomLevelButton onReset={resetZoom} />
         <BarIconButton
           icon="zoom-in"
           label="Zoom In"
           className="appbar-btn"
           onClick={() => zoomIn({ duration: motionDuration(150) })}
         />
-        <BarIconButton icon="zoom-reset" label="Reset" className="appbar-btn" onClick={resetZoom} />
         <BarIconButton
           icon="fit"
           label="Fit All"
@@ -250,7 +380,7 @@ export function AppBar({ store }: { store: SceneStore }) {
       </div>
 
       {/* ARRANGE - acts on the graph's layout and landmarks. */}
-      <div className="appbar-group appbar-tier" data-tier="2">
+      <div className="appbar-group appbar-tier">
         <BarIconButton
           icon="organize"
           label="Organize"
@@ -275,33 +405,34 @@ export function AppBar({ store }: { store: SceneStore }) {
 
       {/* PANELS - canvas appearance and the plugin launcher. Text, because
           both open a surface whose contents the word names. */}
-      <div className="appbar-group appbar-tier" data-tier="3">
-        <BarButton
+      <div className="appbar-group appbar-tier">
+        <BarMenuButton
           label="View"
-          className={chip("view")}
-          trigger="view"
-          pressed={overlays.isOpen("view")}
+          surface="view"
+          labelled
+          isOpen={overlays.isOpen("view")}
           onClick={() => overlays.toggle("view", "popover")}
         />
-        <button
-          type="button"
-          className={chip("plugins")}
-          data-overlay-trigger="plugins"
-          aria-pressed={overlays.isOpen("plugins")}
+        <BarMenuButton
+          label="Plugins"
+          surface="plugins"
+          labelled
+          isOpen={overlays.isOpen("plugins")}
           onClick={() => overlays.toggle("plugins", "popover")}
-        >
-          Plugins <span className="appbar-chevron">&#9662;</span>
-        </button>
+        />
       </div>
 
       <span className="appbar-spacer" />
 
-      {/* Tier-gated the same way as every collapsible group above: CSS only
-          shows this once at least one tier is hidden, so it never appears
-          as a menu button opening an empty menu at full width. */}
+      {/* Gated by the same one breakpoint as every collapsible group above,
+          so it never appears as a menu button opening an empty menu at a
+          normal desktop width. */}
       <button
         type="button"
-        className={"appbar-btn appbar-btn-icon appbar-overflow-trigger" + (overlays.isOpen("toolbar-overflow") ? " checked" : "")}
+        className={
+          "appbar-btn appbar-btn-icon appbar-overflow-trigger" +
+          (overlays.isOpen("toolbar-overflow") ? " checked" : "")
+        }
         data-overlay-trigger="toolbar-overflow"
         aria-label="More toolbar actions"
         aria-haspopup="dialog"
@@ -310,14 +441,25 @@ export function AppBar({ store }: { store: SceneStore }) {
       >
         <AppBarIcon name="more" />
       </button>
-      <Popover name="toolbar-overflow" label="More toolbar actions" className="appbar-overflow-menu">
+      {/* Headings name the toolbar cluster each run of items came from. A
+          seventeen-item flat list is a list of everything, not a menu, and
+          this menu only ever opens as a whole - so the sections are the
+          only structure standing between the reader and the bar they just
+          lost. */}
+      <Popover
+        name="toolbar-overflow"
+        label="More toolbar actions"
+        className="appbar-menu appbar-overflow-menu"
+      >
+        <p className="appbar-menu-heading">
+          Edit and view
+        </p>
         <button
           type="button"
-          className="appbar-overflow-item"
-          data-tier="1"
+          className="appbar-menu-item appbar-overflow-item"
           onClick={() => {
             store.undo();
-            closeOverflow();
+            closeMenu();
           }}
           disabled={!scene.canUndo}
         >
@@ -325,11 +467,10 @@ export function AppBar({ store }: { store: SceneStore }) {
         </button>
         <button
           type="button"
-          className="appbar-overflow-item"
-          data-tier="1"
+          className="appbar-menu-item appbar-overflow-item"
           onClick={() => {
             store.redo();
-            closeOverflow();
+            closeMenu();
           }}
           disabled={!scene.canRedo}
         >
@@ -337,55 +478,54 @@ export function AppBar({ store }: { store: SceneStore }) {
         </button>
         <button
           type="button"
-          className="appbar-overflow-item"
-          data-tier="1"
+          className="appbar-menu-item appbar-overflow-item"
           onClick={() => {
             zoomIn({ duration: motionDuration(150) });
-            closeOverflow();
+            closeMenu();
           }}
         >
           Zoom In
         </button>
         <button
           type="button"
-          className="appbar-overflow-item"
-          data-tier="1"
+          className="appbar-menu-item appbar-overflow-item"
           onClick={() => {
             zoomOut({ duration: motionDuration(150) });
-            closeOverflow();
+            closeMenu();
           }}
         >
           Zoom Out
         </button>
         <button
           type="button"
-          className="appbar-overflow-item"
-          data-tier="1"
+          className="appbar-menu-item appbar-overflow-item"
           onClick={() => {
             resetZoom();
-            closeOverflow();
+            closeMenu();
           }}
         >
           Reset
         </button>
         <button
           type="button"
-          className="appbar-overflow-item"
-          data-tier="1"
+          className="appbar-menu-item appbar-overflow-item"
           onClick={() => {
             fitView({ duration: motionDuration(200), maxZoom: FIT_VIEW_MAX_ZOOM });
-            closeOverflow();
+            closeMenu();
           }}
         >
           Fit All
         </button>
+
+        <p className="appbar-menu-heading">
+          Arrange
+        </p>
         <button
           type="button"
-          className="appbar-overflow-item"
-          data-tier="2"
+          className="appbar-menu-item appbar-overflow-item"
           onClick={() => {
             store.organizeNodes();
-            closeOverflow();
+            closeMenu();
           }}
         >
           Organize
@@ -393,7 +533,6 @@ export function AppBar({ store }: { store: SceneStore }) {
         <button
           type="button"
           className={overflowItem("pins")}
-          data-tier="2"
           aria-pressed={overlays.isOpen("pins")}
           onClick={() => overlays.toggle("pins", "popover")}
         >
@@ -401,19 +540,21 @@ export function AppBar({ store }: { store: SceneStore }) {
         </button>
         <button
           type="button"
-          className="appbar-overflow-item"
-          data-tier="2"
+          className="appbar-menu-item appbar-overflow-item"
           onClick={() => {
             exportPng();
-            closeOverflow();
+            closeMenu();
           }}
         >
           Export PNG
         </button>
+
+        <p className="appbar-menu-heading">
+          Panels
+        </p>
         <button
           type="button"
           className={overflowItem("view")}
-          data-tier="3"
           aria-pressed={overlays.isOpen("view")}
           onClick={() => overlays.toggle("view", "popover")}
         >
@@ -422,16 +563,18 @@ export function AppBar({ store }: { store: SceneStore }) {
         <button
           type="button"
           className={overflowItem("plugins")}
-          data-tier="3"
           aria-pressed={overlays.isOpen("plugins")}
           onClick={() => overlays.toggle("plugins", "popover")}
         >
           Plugins
         </button>
+
+        <p className="appbar-menu-heading">
+          Workspace
+        </p>
         <button
           type="button"
           className={overflowItem("global-search")}
-          data-tier="4"
           aria-pressed={overlays.isOpen("global-search")}
           onClick={() => overlays.toggle("global-search", "dialog")}
         >
@@ -440,7 +583,6 @@ export function AppBar({ store }: { store: SceneStore }) {
         <button
           type="button"
           className={overflowItem("knowledge")}
-          data-tier="4"
           aria-pressed={overlays.isOpen("knowledge")}
           onClick={() => overlays.toggle("knowledge", "dialog")}
         >
@@ -449,7 +591,6 @@ export function AppBar({ store }: { store: SceneStore }) {
         <button
           type="button"
           className={overflowItem("builder-launch")}
-          data-tier="4"
           aria-pressed={overlays.isOpen("builder-launch")}
           onClick={() => overlays.toggle("builder-launch", "dialog")}
         >
@@ -458,7 +599,6 @@ export function AppBar({ store }: { store: SceneStore }) {
         <button
           type="button"
           className={overflowItem("harness-launch")}
-          data-tier="4"
           aria-pressed={overlays.isOpen("harness-launch")}
           onClick={() => overlays.toggle("harness-launch", "dialog")}
         >
@@ -467,7 +607,6 @@ export function AppBar({ store }: { store: SceneStore }) {
         <button
           type="button"
           className={overflowItem("diagnostics")}
-          data-tier="4"
           aria-pressed={overlays.isOpen("diagnostics")}
           onClick={() => overlays.toggle("diagnostics", "dialog")}
         >
@@ -476,7 +615,6 @@ export function AppBar({ store }: { store: SceneStore }) {
         <button
           type="button"
           className={overflowItem("help")}
-          data-tier="4"
           aria-pressed={overlays.isOpen("help")}
           onClick={() => overlays.toggle("help", "dialog")}
         >
@@ -485,7 +623,6 @@ export function AppBar({ store }: { store: SceneStore }) {
         <button
           type="button"
           className={overflowItem("about")}
-          data-tier="4"
           aria-pressed={overlays.isOpen("about")}
           onClick={() => overlays.toggle("about", "dialog")}
         >
@@ -497,10 +634,11 @@ export function AppBar({ store }: { store: SceneStore }) {
           Icon-only: the right end of a permanently-visible bar is where
           density pays, and each carries its full name as tooltip and
           accessible name. */}
-      <div className="appbar-group appbar-tier" data-tier="4">
+      <div className="appbar-group appbar-tier">
         <BarIconButton
           icon="search"
           label="Global Search"
+          hint="Ctrl+F"
           className={chip("global-search")}
           trigger="global-search"
           pressed={overlays.isOpen("global-search")}
@@ -530,29 +668,13 @@ export function AppBar({ store }: { store: SceneStore }) {
           pressed={overlays.isOpen("harness-launch")}
           onClick={() => overlays.toggle("harness-launch", "dialog")}
         />
-        <BarIconButton
-          icon="diagnostics"
-          label="Diagnostics"
-          className={chip("diagnostics")}
-          trigger="diagnostics"
-          pressed={overlays.isOpen("diagnostics")}
-          onClick={() => overlays.toggle("diagnostics", "dialog")}
-        />
-        <BarIconButton
+        <BarMenuButton
+          label="Help and diagnostics"
           icon="help"
-          label="Help"
-          className={chip("help")}
-          trigger="help"
-          pressed={overlays.isOpen("help")}
-          onClick={() => overlays.toggle("help", "dialog")}
-        />
-        <BarIconButton
-          icon="about"
-          label="About"
-          className={chip("about")}
-          trigger="about"
-          pressed={overlays.isOpen("about")}
-          onClick={() => overlays.toggle("about", "dialog")}
+          surface="help-menu"
+          labelled={false}
+          isOpen={overlays.isOpen("help-menu")}
+          onClick={() => overlays.toggle("help-menu", "popover")}
         />
       </div>
 
@@ -569,6 +691,38 @@ export function AppBar({ store }: { store: SceneStore }) {
           onClick={() => overlays.toggle("settings", "dialog")}
         />
       </div>
+
+      {/* Anchored (portaled, then placed from the trigger's own rect),
+          unlike the overflow menu above - nothing in here is width-gated, so
+          it has no reason to stay inside the @container scope, and
+          portaling buys it the viewport flip/clamp every other anchored
+          popover in the app already gets. */}
+      <Popover name="help-menu" label="Help and diagnostics" anchored className="appbar-menu">
+        <button
+          type="button"
+          className={menuItem("help")}
+          aria-pressed={overlays.isOpen("help")}
+          onClick={() => overlays.toggle("help", "dialog")}
+        >
+          Help
+        </button>
+        <button
+          type="button"
+          className={menuItem("diagnostics")}
+          aria-pressed={overlays.isOpen("diagnostics")}
+          onClick={() => overlays.toggle("diagnostics", "dialog")}
+        >
+          Diagnostics
+        </button>
+        <button
+          type="button"
+          className={menuItem("about")}
+          aria-pressed={overlays.isOpen("about")}
+          onClick={() => overlays.toggle("about", "dialog")}
+        >
+          About
+        </button>
+      </Popover>
     </div>
   );
 }

--- a/web_ui/src/app/chrome/AppBarIcon.tsx
+++ b/web_ui/src/app/chrome/AppBarIcon.tsx
@@ -6,6 +6,16 @@
  * fills) so toolbar glyphs sit on the identical visual footing as the rest
  * of the app's chrome rather than introducing a second icon language.
  *
+ * DRAWING CONTRACT. Every glyph here renders at 16px (.appbar-btn .icon),
+ * i.e. a 24-unit view box scaled to 0.67 - so a stroke that crosses another
+ * stroke inside a ~4-unit span merges into a blob at the size it actually
+ * ships at. Two rules follow, and both are load-bearing rather than
+ * stylistic: keep interior detail at least 3 view-box units clear of any
+ * other stroke, and prefer one recognisable silhouette over an accurate
+ * miniature. `knowledge` and `builder` were both redrawn against exactly
+ * this rule after rendering as an anonymous rectangle and an anonymous
+ * diagonal respectively.
+ *
  * Its own module rather than a local in AppBar.tsx: `react-refresh/
  * only-export-components` flags a component file that exports more than
  * components, and keeping the glyph table separate leaves AppBar.tsx as
@@ -19,7 +29,6 @@ export type AppBarIconName =
   | "redo"
   | "zoom-in"
   | "zoom-out"
-  | "zoom-reset"
   | "fit"
   | "organize"
   | "pin"
@@ -32,6 +41,7 @@ export type AppBarIconName =
   | "settings"
   | "help"
   | "about"
+  | "chevron"
   | "more";
 
 export function AppBarIcon({ name }: { name: AppBarIconName }) {
@@ -62,13 +72,6 @@ export function AppBarIcon({ name }: { name: AppBarIconName }) {
         <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
           <circle cx="10.5" cy="10.5" r="6.5" />
           <path d="m20 20-4.8-4.8M7.5 10.5h6" />
-        </svg>
-      );
-    case "zoom-reset":
-      return (
-        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
-          <circle cx="12" cy="12" r="7.5" />
-          <circle cx="12" cy="12" r="2" />
         </svg>
       );
     case "fit":
@@ -114,10 +117,17 @@ export function AppBarIcon({ name }: { name: AppBarIconName }) {
         </svg>
       );
     case "builder":
+      // A wand with one spark - the Builder writes a whole graph from a
+      // prompt (ADR-008), which is a "generate this for me" affordance, not
+      // a "tighten this bolt" one. The wrench it replaces collapsed into a
+      // single anonymous diagonal at 16px because its jaw was a 4-unit
+      // detail; a shaft plus a detached spark keeps two clearly separated
+      // marks at any size.
       return (
         <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
-          <path d="M14 4a4 4 0 0 0-4 5l-6 6 3 3 6-6a4 4 0 0 0 5-4Z" />
-          <path d="m14.5 9.5 4 4" />
+          <path d="M4.5 19.5 14 10" />
+          <path d="m12.5 8.5 3 3 4-4-3-3z" />
+          <path d="M6 3.5v3M4.5 5h3" />
         </svg>
       );
     case "agent":
@@ -126,9 +136,9 @@ export function AppBarIcon({ name }: { name: AppBarIconName }) {
       // shorthand for that kind of surface.
       return (
         <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
-          <rect x="3" y="5" width="18" height="14" rx="2" />
-          <path d="m7 10 3 2.5L7 15" />
-          <path d="M12.5 15H17" />
+          <rect x="3" y="4.5" width="18" height="15" rx="2.5" />
+          <path d="m7 9.5 3.5 2.5L7 14.5" />
+          <path d="M13 15h4" />
         </svg>
       );
     case "diagnostics":
@@ -164,6 +174,17 @@ export function AppBarIcon({ name }: { name: AppBarIconName }) {
           <circle cx="12" cy="12" r="8.5" />
           <path d="M12 11v5.5" />
           <path d="M12 7.8v.01" />
+        </svg>
+      );
+    case "chevron":
+      // The disclosure mark on View/Plugins/Help. Previously a literal
+      // "&#9662;" text glyph, which took its weight from the font rather
+      // than from the icon set and therefore sat visibly heavier and lower
+      // than every stroke next to it. As an <svg class="icon"> it inherits
+      // the same 1.7 stroke and the same currentColor as its own label.
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon icon-chevron">
+          <path d="m7 10 5 5 5-5" />
         </svg>
       );
     case "more":

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1458,7 +1458,25 @@ body,
    absorb or surrender space, and the `0` floor is what lets it shrink below
    its content's intrinsic width so the toolbar's own container queries -
    not the window - decide what collapses. Both outer tracks are `auto`,
-   i.e. exactly as wide as they need and never wider. */
+   i.e. exactly as wide as they need and never wider.
+
+   ONE METRIC SET, used by everything in this bar, so a control's size is
+   never a local decision:
+
+     row height          44px
+     control height      28px  (identical for text, icon and menu buttons)
+     icon box            28px square
+     glyph               16px, 1.7 stroke
+     radius              7px
+     spacing INSIDE a group     2px
+     spacing BETWEEN groups    12px, with a hairline rule centred in it
+
+   The 2px/12px ratio is the whole grouping mechanism: proximity does the
+   work, the hairline only confirms it. What this replaced gave every group
+   a filled, bordered, padded box of its own - nine such boxes in a 44px
+   strip, so the containers were louder than the controls inside them, and
+   any two-button group read as a segmented control rather than as two
+   unrelated commands. */
 
 .app-topbar {
   display: grid;
@@ -1469,8 +1487,8 @@ body,
      its gutter and push the toolbar off the right edge asymmetrically. */
   column-gap: 0;
   /* Fixed row height: the bar must not resize with its contents. */
-  height: 46px;
-  padding: 0 14px;
+  height: 44px;
+  padding: 0 10px;
   background-color: var(--gl-surface-node-body);
   border-bottom: 1px solid var(--gl-surface-border);
   /* Deliberately NO overflow-x here, despite that being the obvious
@@ -1486,27 +1504,45 @@ body,
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-right: 16px;
+  /* The brand is a zone, not a toolbar group: it gets the same 12px gutter
+     and the same hairline every group boundary gets, so the eye reads one
+     consistent rhythm across the whole row rather than a special case at
+     the left end. */
+  position: relative;
+  padding: 0 12px 0 4px;
+  margin-right: 12px;
   /* The brand never shrinks or wraps - it is the anchor the rest of the bar
      is measured from. */
   flex-shrink: 0;
 }
 
+.app-topbar-brand::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 1px;
+  height: 18px;
+  transform: translateY(-50%);
+  background-color: var(--gl-surface-divider);
+}
+
 .app-brand-mark {
-  width: 17px;
-  height: 17px;
+  width: 18px;
+  height: 18px;
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.6;
+  stroke-width: 1.7;
   stroke-linecap: round;
   stroke-linejoin: round;
-  color: var(--gl-surface-text-secondary);
+  color: var(--gl-surface-text-primary);
 }
 
 .app-title {
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.01em;
+  color: var(--gl-surface-text-strong);
   white-space: nowrap;
 }
 
@@ -1525,7 +1561,7 @@ body,
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  margin-left: 16px;
+  margin-left: 12px;
 }
 
 .app-topbar-status:empty {
@@ -1570,10 +1606,10 @@ body,
 .appbar {
   display: flex;
   align-items: center;
-  /* Space BETWEEN groups. Within a group the spacing is tighter (see
-     .appbar-group) - that difference is what makes the grouping legible
-     without needing a rule between every pair of buttons. */
-  gap: 10px;
+  /* Space BETWEEN groups. Within a group the spacing is 2px (see
+     .appbar-group) - that 6:1 ratio is what makes the grouping legible on
+     its own, before the hairline below reinforces it. */
+  gap: 12px;
   /* Lets the middle grid track actually shrink; container-type/name is what
      the @container queries at the bottom of this block key off. Deliberately
      NOT `overflow: hidden` - an overflow:hidden ancestor clips ANY
@@ -1585,41 +1621,61 @@ body,
   container-name: appbar;
 }
 
-/* A cluster of related actions on one shared surface. Uniform inner
-   spacing and a single rounded container is what carries this bar's visual
-   organisation; the run of twenty text buttons this replaced used ad-hoc
-   1px rules and identical spacing everywhere, so nothing read as related
-   to anything else. */
+/* A cluster of related actions. Flat - no fill, no border, no padding of
+   its own; the group is a spacing decision, not a drawn object. */
 .appbar-group {
   display: flex;
   align-items: center;
   gap: 2px;
-  padding: 3px;
-  background-color: var(--gl-surface-inset);
-  border: 1px solid var(--gl-surface-border);
-  border-radius: 8px;
   flex-shrink: 0;
+  position: relative;
+}
+
+/* The boundary rule between two adjacent groups, drawn on the SECOND of the
+   pair rather than as an element of its own between them. Groups collapse
+   at narrow widths (the tier mechanism at the end of this block); a
+   free-standing separator element would survive its neighbours and be left
+   as a stray rule floating in the gap. Attached here it disappears with the
+   group it introduces.
+
+   `+` adjacency is DOM order, not layout: a display:none group still counts
+   as the previous sibling, so hiding a tier never breaks the chain for the
+   groups after it. .appbar-spacer sits between the two halves of the bar
+   and is not a .appbar-group, which is exactly why the right-hand cluster
+   starts without a leading rule. */
+.appbar-group + .appbar-group::before {
+  content: "";
+  position: absolute;
+  left: -7px;
+  top: 50%;
+  width: 1px;
+  height: 18px;
+  transform: translateY(-50%);
+  background-color: var(--gl-surface-divider);
 }
 
 .appbar-btn {
   /* Fixed height on every control, so the row's own height is a constant
      and never a function of which buttons happen to be showing. */
-  height: 26px;
+  height: 28px;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
   padding: 0 10px;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   font-family: inherit;
+  line-height: 1;
   color: var(--gl-surface-text-secondary);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: 7px;
   cursor: pointer;
   white-space: nowrap;
   transition:
     background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    border-color var(--gl-motion-fast) var(--gl-motion-ease),
     color var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
@@ -1628,166 +1684,256 @@ body,
 .appbar-btn-icon {
   width: 28px;
   padding: 0;
-  justify-content: center;
 }
 
 .appbar-btn .icon {
-  width: 15px;
-  height: 15px;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.6;
+  stroke-width: 1.7;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
 
+/* A control that opens a panel rather than performing an action. The
+   chevron is deliberately quieter than the label it follows - it is a
+   property of the control, not a second thing to read - and tighter to the
+   right edge so the label stays optically centred in the button. */
+.appbar-btn-menu {
+  gap: 4px;
+  padding-right: 7px;
+}
+
+.appbar-btn-menu.appbar-btn-icon {
+  width: auto;
+  padding: 0 5px 0 6px;
+}
+
+.appbar-btn .icon-chevron {
+  width: 12px;
+  height: 12px;
+  opacity: 0.75;
+}
+
+/* The live zoom readout. Tabular figures plus a floor on the width keep
+   "25%" and "100%" the same size, so nothing either side of it shifts as
+   the viewport changes. */
+.appbar-btn-zoom {
+  min-width: 46px;
+  padding: 0 6px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+}
+
 .appbar-btn:hover:enabled {
-  background-color: var(--gl-neutral-button-hover);
+  background-color: var(--gl-neutral-button-background);
   color: var(--gl-surface-text-primary);
+}
+
+/* Press feedback, which this bar had none of - a click landed with no
+   acknowledgement other than whatever the click itself caused. One step
+   past hover in the same direction (darker in the light palette, lighter in
+   the dark one), so the three states read as one scale. */
+.appbar-btn:active:enabled {
+  background-color: var(--gl-neutral-button-hover);
+  color: var(--gl-surface-text-bright);
 }
 
 .appbar-btn:focus-visible {
   outline: 2px solid var(--gl-focus-ring);
-  outline-offset: -1px;
+  outline-offset: 1px;
 }
 
+/* Muted rather than faded. `opacity: 0.35` on a #BDBDBD glyph over a
+   #252525 bar lands at roughly #3B3B3B - a control that has effectively
+   vanished rather than one that is present and unavailable, which is what
+   Undo and Redo look like for most of a session. The muted token is a real
+   colour with real contrast against both palettes' bar surface. */
 .appbar-btn:disabled {
-  opacity: 0.35;
+  color: var(--gl-surface-text-muted);
   cursor: default;
 }
 
-/* Open-surface state. The filled treatment is reserved for this one meaning
-   across the whole bar, so "this panel is open" is never confusable with
-   hover or focus. */
+/* Open-surface state. Reserved for this one meaning across the whole bar,
+   and it has to outrank hover, not tie with it - the old rule painted the
+   open state DARKER than the hover state, so hovering an inactive button
+   looked more active than the panel that was actually open. It sits one
+   step above hover on the same scale and adds a border and brighter text,
+   which no other state uses. */
 .appbar-btn-checkable.checked {
-  background-color: var(--gl-neutral-button-background);
+  background-color: var(--gl-neutral-button-hover);
   border-color: var(--gl-neutral-button-border);
   color: var(--gl-surface-text-bright);
 }
 
 .appbar-spacer {
   flex: 1;
-  /* A real minimum, so the two clusters can never meet even at the
-     narrowest width the tiers allow. */
-  min-width: 12px;
+  /* A real minimum, so the two halves of the bar can never meet even at
+     the narrowest width the spill guard allows. */
+  min-width: 16px;
 }
 
-.appbar-chevron {
-  font-size: 9px;
-  opacity: 0.75;
-}
-
-/* The overflow trigger. Hidden by default; the container-query block below
-   reveals it once ANY tier has collapsed, and reveals each menu item once
-   ITS OWN tier has collapsed - the item's data-tier is the same value used
-   on the inline group, so the two stay in lockstep with no JS. */
+/* The overflow trigger. Hidden by default; the single container query at
+   the end of this block reveals it and the menu's contents together, so the
+   button and the things it opens can never disagree about whether the bar
+   has folded. */
 .appbar-overflow-trigger {
   display: none;
   flex-shrink: 0;
 }
 
-/* .overlay-popover (the base class Popover always applies alongside this
-   one) already supplies background/border/shadow and default sizing - only
-   what is genuinely different for a button-list menu is overridden here.
-   Position is the one property .overlay-popover never sets for any
-   consumer: View/Plugins/Pins get theirs from a dedicated wrapper div in
-   App.tsx, and this one has none, so it is anchored here to .appbar's own
-   right edge (position: relative on .appbar above). */
-.appbar-overflow-menu {
+/* -- Toolbar menus (the overflow list and the Help menu) ------------------
+
+   .overlay-popover (the base class Popover always applies alongside these)
+   already supplies background/border/shadow and default sizing - only what
+   is genuinely different for a button-list menu is overridden here.
+
+   Both selectors are qualified with .overlay-popover rather than written as
+   a bare .appbar-menu, and that is load-bearing, not decoration. Popover
+   emits `class="overlay-popover ... appbar-menu"`, so the two classes tie
+   on specificity and the later rule in this file wins - and .overlay-popover
+   is defined further down. A bare .appbar-menu therefore loses every
+   property the base class also sets (padding, min-width, radius,
+   max-height), which is exactly what the previous .appbar-overflow-menu
+   rule did: it asked for a 6px pad and a 180px floor and silently rendered
+   at the dialog-sized 12px/14px pad and 230px floor instead. Qualifying the
+   selector settles the tie in the variant's favour. */
+
+.overlay-popover.appbar-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 190px;
+  padding: 6px;
+  border-radius: 10px;
+}
+
+/* Position is the one property .overlay-popover never sets for any
+   consumer. View/Plugins/Pins/Help are `anchored` and get theirs computed
+   from the trigger's rect (useAnchoredPlacement in overlays.tsx); this menu
+   cannot be - it is tier-gated, and an anchored Popover portals to
+   document.body, which would take it out of the `@container appbar` scope
+   its items depend on - so it stays a descendant and is positioned against
+   .appbar's own right edge (position: relative on .appbar above). */
+.overlay-popover.appbar-overflow-menu {
   position: absolute;
   top: 100%;
   right: 0;
   margin-top: 6px;
   z-index: var(--gl-z-node-menu);
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 180px;
-  padding: 6px;
-  border-radius: 8px;
-  max-height: calc(100vh - 16px);
+  /* The menu hangs BELOW the bar (top: 100% + 6px), so the space it
+     actually has is the viewport minus everything above it, not the whole
+     viewport. `calc(100vh - 16px)` ignored that and let a full list run off
+     the bottom of a short window with no way to reach the last items. 58px
+     is the 44px row, the 6px offset and a 8px bottom margin. */
+  max-height: calc(100vh - 58px);
   overflow-y: auto;
 }
 
-.appbar-overflow-item {
-  display: none;
+/* Section labels, matching the toolbar clusters the items came from - a
+   seventeen-item flat list is a list of everything, not a menu. Same
+   treatment as .view-section-title so the two menus in this app read as one
+   family. */
+.appbar-menu-heading {
+  margin: 8px 0 2px;
+  padding: 0 8px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--gl-surface-text-muted);
+}
+
+.appbar-menu-heading:first-child {
+  margin-top: 2px;
+}
+
+.appbar-menu-item {
+  display: block;
   width: 100%;
   text-align: left;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   font-family: inherit;
-  padding: 6px 10px;
+  padding: 7px 10px;
   color: var(--gl-surface-text-primary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: 6px;
   cursor: pointer;
+  transition: background-color var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
-.appbar-overflow-item:hover:enabled {
+.appbar-menu-item:hover:enabled {
   background-color: var(--gl-neutral-button-hover);
+  color: var(--gl-surface-text-bright);
 }
 
-.appbar-overflow-item:disabled {
-  opacity: 0.35;
+.appbar-menu-item:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: -2px;
+}
+
+.appbar-menu-item:disabled {
+  color: var(--gl-surface-text-muted);
   cursor: default;
 }
 
 /* Mirrors .appbar-btn-checkable.checked for the menu copies. Note this can
    never actually render true in practice: OverlayProvider is single-open,
    so by the time any of Pins/View/Plugins/About/Help becomes the open
-   surface, "toolbar-overflow" has stopped being it and this menu has
+   surface, the menu holding this item has stopped being it and has
    unmounted. Kept anyway so both copies of a control state the same
    contract. */
-.appbar-overflow-item.checked {
-  background-color: var(--gl-neutral-button-background);
+.appbar-menu-item.checked {
+  background-color: var(--gl-neutral-button-hover);
   border-color: var(--gl-neutral-button-border);
+  color: var(--gl-surface-text-bright);
 }
 
-/* Tiers collapse whole GROUPS, not individual buttons, so a cluster is
-   never left as a fragment of itself. Order is by how recoverable the
-   actions are elsewhere: history and viewport first (both have keyboard
-   and wheel equivalents), then arrange, then the panels, then the
-   workspace-tools cluster. Session (Library/Save) and Settings have no
-   tier at all - those are exactly what finding #5 flagged as becoming
-   unreachable, so they never collapse. */
-@container appbar (max-width: 900px) {
+/* The overflow menu's own contents are the duplicate copies, so they stay
+   out of the way until the bar has actually folded. The Help menu's items
+   carry .appbar-menu-item alone and are always present. */
+.appbar-overflow-item,
+.appbar-overflow-menu .appbar-menu-heading {
+  display: none;
+}
+
+/* -- The spill guard ------------------------------------------------------
+
+   ONE breakpoint, and it is a floor rather than a layout. Graphlink is
+   desktop-only software: this bar is designed for a desktop window and
+   there is no phone layout here to grade towards. What this rule prevents
+   is the specific failure R8a filed as finding #5 - dragged narrower than
+   its own contents, the toolbar ran off the right edge of the window and
+   dragged a horizontal scrollbar across the whole document.
+
+   So below the width at which the full bar fits, every collapsible group
+   moves into the overflow menu at once. Library/Save and Settings have no
+   .appbar-tier and never move - those are exactly the controls finding #5
+   flagged as becoming unreachable. Whole GROUPS move, never individual
+   buttons, so a cluster is never left as a fragment of itself.
+
+   The query measures .appbar itself (container-type: inline-size above),
+   not the viewport: the brand and status regions either side of it take
+   real width, so the toolbar's own room is the only honest thing to test.
+   820px is the measured point at which the assembled groups plus their
+   gaps stop fitting, with a small margin. */
+@container appbar (max-width: 820px) {
   .appbar-overflow-trigger {
     display: inline-flex;
     align-items: center;
     justify-content: center;
   }
-  .appbar-tier[data-tier="1"] {
+  .appbar-tier {
     display: none;
   }
-  .appbar-overflow-item[data-tier="1"] {
+  .appbar-overflow-item {
     display: block;
   }
-}
-
-@container appbar (max-width: 720px) {
-  .appbar-tier[data-tier="2"] {
-    display: none;
-  }
-  .appbar-overflow-item[data-tier="2"] {
-    display: block;
-  }
-}
-
-@container appbar (max-width: 560px) {
-  .appbar-tier[data-tier="3"] {
-    display: none;
-  }
-  .appbar-overflow-item[data-tier="3"] {
-    display: block;
-  }
-}
-
-@container appbar (max-width: 400px) {
-  .appbar-tier[data-tier="4"] {
-    display: none;
-  }
-  .appbar-overflow-item[data-tier="4"] {
+  .appbar-overflow-menu .appbar-menu-heading {
     display: block;
   }
 }


### PR DESCRIPTION
## Problem

The top bar was carried over from the Qt toolbar island largely unchanged.

- Every group was a filled, bordered, padded container. Nine of them in a 46px strip; a two-button group such as Library/Save read as a segmented control.
- The open-panel state (`--gl-neutral-button-background`, `#393939`) was darker than the hover state (`--gl-neutral-button-hover`, `#484848`), so hovering an inactive button looked more active than the open panel.
- No press state.
- Disabled was `opacity: 0.35` on a `#BDBDBD` glyph over a `#252525` bar, resolving to roughly `#3B3B3B`.
- Text buttons were 26px and icon buttons 28px within the same group. The Plugins chevron was a text glyph rather than part of the icon set.
- Seven icons of identical weight at the right end, ranging from Global Search to About.
- Reset Zoom was drawn as two concentric circles.

## Change

- Groups are flat. 2px within a group, 12px between, one hairline rule between adjacent groups, drawn as a pseudo-element on the following group so it disappears with the group it introduces.
- One metric set: 44px row, 28px controls, 28px icon box, 16px glyphs at 1.7 stroke, 7px radius.
- Idle, hover, pressed and open step in one direction on both palettes. Open additionally carries a border and brighter text. Disabled uses the muted text token instead of an opacity wash.
- Reset Zoom replaced with a live zoom-percentage control that resets to 100%. It subscribes to the React Flow transform in its own component so a wheel-zoom re-renders one button.
- Help, Diagnostics and About consolidated into one Help menu, reducing the right-hand run from seven icons to five. Both remain reachable from the command palette and the overflow menu.
- Overflow menu gains section headings matching the toolbar clusters.
- Ctrl+L, Ctrl+S, Ctrl+Z, Ctrl+Shift+Z and Ctrl+F named in tooltips only, never in accessible names.
- The graded four-tier collapse (860/680/520/380px) is replaced by a single breakpoint. This is desktop software; the rule exists only to prevent a narrowed window running the toolbar off the right edge (R8a finding #5).

Two further fixes:

1. `.appbar-overflow-menu` tied with `.overlay-popover` on specificity and lost, rendering at 12px/14px padding and a 230px floor instead of the 6px/180px requested. Both toolbar-menu selectors are now qualified with `.overlay-popover`.
2. The overflow menu's `max-height: calc(100vh - 16px)` did not account for it hanging below the bar, so a full list ran off the bottom of short windows. Now `calc(100vh - 58px)`.

## Test plan

- `AppBar.test.tsx`: 29 pass, up from 18. New coverage for the Help menu, the zoom readout, and the tooltip-only keyboard-hint contract. The `data-tier` pairing assertions are replaced by the membership invariant that survives the simplification.
- `npx vitest run` (full frontend suite): 2043 pass, with the pre-existing failures on this checkout unrelated to and untouched by this branch.
- `npm run lint` and `tsc --noEmit` clean for all four files.
- Manual at 1099px: full bar, no overflow trigger, separators present on exactly the intended groups. Verified the fold at reduced widths produces no horizontal document overflow, that the Help and View popovers anchor to their triggers, and that the light palette's state scale is monotonic.
