### PR TITLE
Add an SPA bundle staleness check to the session Stop hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/tools/rebuild-spa-if-stale.sh\"",
+            "timeout": 180,
+            "statusMessage": "Checking the SPA bundle is current..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,13 @@
 *.txt text eol=crlf
 *.md text eol=crlf
 
+# Shell scripts must check out with LF on every platform. A CRLF shebang
+# line is a syntax error to the interpreter ("bad interpreter: no such file
+# or directory"), so a script normalized to CRLF on a Windows checkout is
+# broken for anyone who runs it under bash - including the SPA staleness
+# guard in tools/.
+*.sh text eol=lf
+
 *.png binary
 *.ico binary
 *.wav binary

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,15 @@ ENV/
 
 # Claude Code local tooling config (e.g. launch.json for the Browser pane's
 # dev-server preview) - per-developer/per-agent, never shared repo config.
-.claude/
+#
+# `.claude/*` rather than `.claude/` so git will descend into the directory
+# at all: a negation cannot re-include a file underneath an excluded
+# DIRECTORY, only underneath excluded contents. settings.json is the one
+# carve-out - it is shared repo config (the SPA bundle staleness guard, see
+# tools/rebuild-spa-if-stale.sh), which is exactly the thing that has to
+# survive a fresh clone rather than be re-derived per developer.
+.claude/*
+!.claude/settings.json
 
 # OS files
 .DS_Store

--- a/tools/rebuild-spa-if-stale.sh
+++ b/tools/rebuild-spa-if-stale.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Rebuild the SPA bundle whenever it is older than the source it is built
+# from.
+#
+# WHY THIS EXISTS. The app does not run the source tree. Both the desktop
+# shell (graphlink_desktop.py) and the FastAPI backend (backend/app.py,
+# SPA_DIST_DIR) serve web_ui/dist/app - a Vite build. `npm run dev` on :5173
+# reads source live, so it is entirely possible to change the UI, verify it
+# in the dev server, and have the real application go on serving a bundle
+# built days earlier. That happened: the toolbar and Builder rebuilds were
+# verified on :5173 while the app served an eleven-day-old bundle, and the
+# work looked like it had never landed.
+#
+# dist/ is gitignored, so CI cannot catch this - it is a local-state problem
+# and needs a local guard. This runs from a Stop hook (.claude/settings.json)
+# and rebuilds only when the bundle is actually behind, so a turn that
+# touched no frontend source costs one `find`.
+#
+# It deliberately does NOT gate on git state. The bundle's job is to reflect
+# the working tree, which is what the developer is looking at.
+
+set -u
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+src="$root/web_ui/src"
+stamp="$root/web_ui/dist/app/index.html"
+
+# Nothing to do outside a checkout that has the frontend.
+[ -d "$src" ] || exit 0
+
+emit() { printf '{"systemMessage":%s}\n' "$1"; }
+
+# Inputs that change what the bundle contains. index.html lives under
+# src/app/, so it is already covered by the tree walk.
+newest="$(
+  find "$src" -type f -newer "$stamp" -print -quit 2>/dev/null
+)"
+if [ ! -f "$stamp" ]; then
+  newest="(no bundle yet)"
+elif [ -z "$newest" ]; then
+  for f in "$root/web_ui/vite.config.ts" "$root/web_ui/package.json"; do
+    [ -f "$f" ] && [ "$f" -nt "$stamp" ] && newest="$f" && break
+  done
+fi
+
+[ -n "$newest" ] || exit 0
+
+if (cd "$root/web_ui" && npm run build >/tmp/graphlink-spa-build.log 2>&1); then
+  emit '"web_ui/dist/app rebuilt - the desktop app and :8765 now serve the current source."'
+else
+  emit '"web_ui/dist/app is STALE: npm run build failed. See /tmp/graphlink-spa-build.log. The desktop app and :8765 are still serving the previous bundle."'
+fi
+exit 0


### PR DESCRIPTION
## Problem

The app does not run the source tree. Both the desktop shell (`graphlink_desktop.py`) and the FastAPI backend (`backend/app.py`, `SPA_DIST_DIR`) serve `web_ui/dist/app` — a Vite build. `npm run dev` on `:5173` reads source live.

So it is entirely possible to change the UI, verify it against the dev server, and have the real application go on serving a bundle built days earlier. That is what happened while the toolbar (#372) and Builder (#373) rebuilds were being verified: `:5173` showed the new work, the app served an eleven-day-old bundle, and the changes looked like they had never landed.

`dist/` is gitignored, so CI cannot catch this. It is local state, so the guard is local.

## Change

- **`tools/rebuild-spa-if-stale.sh`** compares the newest file under `web_ui/src` (plus `vite.config.ts` and `package.json`) against `web_ui/dist/app/index.html`, and rebuilds only when the bundle is actually behind. A turn that touched no frontend source costs one `find`. A failed build reports itself rather than failing silently.
- **`.claude/settings.json`** runs it from a `Stop` hook, so the bundle is current by the end of any session turn that changed the frontend.

Two supporting changes, both load-bearing rather than tidying:

- **`.gitignore`**: `.claude/*` instead of `.claude/`, with `settings.json` as the one carve-out. A negation cannot re-include a file underneath an excluded *directory*, only underneath excluded *contents*, so the directory rule had to change for git to descend at all. `launch.json` stays ignored — that one really is per-developer.
- **`.gitattributes`**: `*.sh text eol=lf`. A CRLF shebang is a syntax error to the interpreter, so a shell script normalized to CRLF on a Windows checkout is broken for anyone who runs it under bash — including this one.

## Test plan

- Ran the guard against a current bundle: exits 0, no output, no build.
- Touched `web_ui/src/app/styles.css` and ran it again: rebuilt, and emitted the `systemMessage` JSON the hook contract expects. Confirmed `web_ui/dist/app/index.html` was rewritten.
- Ran the exact command string from `settings.json` (`bash "${CLAUDE_PROJECT_DIR:-.}/tools/rebuild-spa-if-stale.sh"`) rather than only the script path, so the quoting and the fallback are covered.
- Validated the hook JSON parses and the command is nested where the Stop-hook schema expects it.
- Deleted and re-checked-out the script to confirm the new `eol=lf` attribute takes effect: 0 CRLF bytes, still executes.
- Verified `.claude/settings.json` is stageable and `.claude/launch.json` is still ignored.
