### PR TITLE
Rebuild the View panel

### DIFF
--- a/web_ui/e2e/boot.spec.ts
+++ b/web_ui/e2e/boot.spec.ts
@@ -33,8 +33,10 @@ test("boots against the real backend and renders the canvas shell", async ({ pag
   // has no visible text to check on the happy path this test exercises.
   await expect(page.locator('.app-shell[data-connection-status="open"]')).toBeAttached();
 
-  // A fresh session has zero nodes - SceneCanvas.tsx's own empty-state hint
-  // is the honest "nothing broken, genuinely nothing here yet" signal for
-  // that case (see its own comment on why this exists at all).
-  await expect(page.locator(".scene-empty-hint")).toBeVisible();
+  // A fresh session has zero nodes, and that is asserted directly now. It
+  // used to be asserted through SceneCanvas.tsx's empty-canvas hint - a
+  // full-canvas overlay that has since been removed for painting itself
+  // over every popover anchored on the canvas. An empty canvas is the state
+  // this line was always about; the overlay was only ever a proxy for it.
+  await expect(page.locator(".react-flow__node")).toHaveCount(0);
 });

--- a/web_ui/e2e/create-node.spec.ts
+++ b/web_ui/e2e/create-node.spec.ts
@@ -33,11 +33,13 @@ test("creates a node by double-click, then a Conversation Node via the Plugins p
   const canvas = page.getByTestId("scene-canvas");
   const box = await canvas.boundingBox();
   if (!box) throw new Error("scene-canvas has no layout box to click into");
-  // Deliberately NOT the canvas's exact center: SceneCanvas.tsx's own empty-
-  // state hint (".scene-empty-hint", styles.css) is centered with `inset: 0`
-  // + flexbox centering and stays mounted until the first node exists - a
-  // dblclick at width/2,height/2 lands ON its real "Load Sample Workspace"
-  // button instead of blank canvas. A corner offset stays clear of it.
+  // A corner offset rather than the canvas's exact center. This used to be
+  // load-bearing: a full-canvas empty-state hint was centered over the
+  // canvas until the first node existed, so a dblclick at width/2,height/2
+  // landed on its "Load Sample Workspace" button instead of blank canvas.
+  // That overlay is gone, so any point on the canvas would do now - the
+  // offset is kept because the exact coordinates are arbitrary either way
+  // and moving them would churn a passing test for nothing.
   await canvas.dblclick({ position: { x: box.width * 0.15, y: box.height * 0.15 } });
 
   await expect(page.locator(".react-flow__node")).toHaveCount(1);

--- a/web_ui/e2e/workspace-save-reload.spec.ts
+++ b/web_ui/e2e/workspace-save-reload.spec.ts
@@ -62,10 +62,10 @@ test("saves a node, clears the canvas, then reloads it from the chat library", a
   const canvas = page.getByTestId("scene-canvas");
   const box = await canvas.boundingBox();
   if (!box) throw new Error("scene-canvas has no layout box to click into");
-  // Off-center on purpose - see create-node.spec.ts's own comment: a click
-  // at the exact center lands on the empty-state hint's real "Load Sample
-  // Workspace" button (styles.css's ".scene-empty-hint" is centered with
-  // `inset: 0`) rather than blank canvas.
+  // A corner offset rather than the exact center - see create-node.spec.ts's
+  // own comment. It used to be dodging the empty-state hint's "Load Sample
+  // Workspace" button; that overlay is gone, and the offset is kept only
+  // because the coordinates are arbitrary either way.
   await canvas.dblclick({ position: { x: box.width * 0.15, y: box.height * 0.15 } });
   await expect(page.locator(".react-flow__node")).toHaveCount(1);
 

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -3109,14 +3109,13 @@ describe("SceneCanvas version-rejection gate (ADR-003 stage 3.5)", () => {
   });
 });
 
-describe("SceneCanvas empty-canvas hint (ADR-012 stage 12.6)", () => {
+describe("SceneCanvas empty canvas", () => {
   type StateListener = (payload: Record<string, unknown>) => void;
 
   // Same minimal transport shape as makeStoreWithVersionControl above (a
   // sibling, not reused, since it is scoped to that describe block) - just
-  // enough of WsTransport's surface for SceneCanvas to mount and for a test
-  // to push a real scene snapshot afterward.
-  function makeStoreForEmptyHint() {
+  // enough of WsTransport's surface for SceneCanvas to mount.
+  function makeStoreForEmptyCanvas() {
     const stateListeners = new Map<string, StateListener>();
     const transport = {
       subscribe: vi.fn((topic: string, listener: StateListener) => {
@@ -3137,42 +3136,21 @@ describe("SceneCanvas empty-canvas hint (ADR-012 stage 12.6)", () => {
     return { store, transport, stateListeners };
   }
 
-  const HINT_TEXT = "Type a message to start, or load the sample workspace.";
-
-  it("renders the empty-canvas hint when the scene has no nodes", () => {
-    const { store } = makeStoreForEmptyHint();
-
-    render(
-      <ReactFlowProvider>
-        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
-      </ReactFlowProvider>,
-    );
-
-    expect(screen.getByText(HINT_TEXT)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Load Sample Workspace" })).toBeInTheDocument();
-  });
-
-  it("hides the empty-canvas hint once the scene has a real node", () => {
-    const { store, stateListeners } = makeStoreForEmptyHint();
-
-    render(
-      <ReactFlowProvider>
-        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
-      </ReactFlowProvider>,
-    );
-    expect(screen.getByText(HINT_TEXT)).toBeInTheDocument();
-
-    act(() => {
-      stateListeners.get("scene")!(
-        baseScene({ nodes: [baseNode({ id: "n1" })] }) as unknown as Record<string, unknown>,
-      );
-    });
-
-    expect(screen.queryByText(HINT_TEXT)).toBeNull();
-  });
-
-  it("the Load Sample Workspace button fires the scene-topic loadSampleWorkspace intent", () => {
-    const { store, transport } = makeStoreForEmptyHint();
+  // ADR-012 stage 12.6 added a full-canvas "Type a message to start, or load
+  // the sample workspace" overlay with a Load Sample Workspace button. It is
+  // gone, and this is the guard against it coming back.
+  //
+  // It was not merely unwanted - it was painted at --gl-z-canvas-hud (21),
+  // the tier reserved for the token counter and the minimap, which each own
+  // a screen CORNER. This overlay was `position: absolute; inset: 0`, so it
+  // claimed the whole canvas at a tier ABOVE --gl-z-app-layer (20) - every
+  // popover anchored over the canvas, View and Plugins and Pins included.
+  // Its text and its button painted straight through all of them.
+  //
+  // The loadSampleWorkspace intent itself is untouched: OnboardingDialog
+  // still offers it, in a dialog, where a first-run affordance belongs.
+  it("renders no overlay on an empty scene - no hint text, no button over the canvas", () => {
+    const { store } = makeStoreForEmptyCanvas();
 
     render(
       <ReactFlowProvider>
@@ -3180,7 +3158,8 @@ describe("SceneCanvas empty-canvas hint (ADR-012 stage 12.6)", () => {
       </ReactFlowProvider>,
     );
 
-    screen.getByRole("button", { name: "Load Sample Workspace" }).click();
-    expect(transport.fireIntent).toHaveBeenCalledWith("scene", "loadSampleWorkspace", []);
+    expect(screen.queryByText(/load the sample workspace/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Load Sample Workspace" })).toBeNull();
+    expect(document.querySelector(".scene-empty-hint")).toBeNull();
   });
 });

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -2856,20 +2856,6 @@ function CanvasInner({
           </ViewportPortal>
         )}
       </ReactFlow>
-      {/* ADR-012 stage 12.6: a non-blank empty-canvas hint - a fresh
-          session's scene is otherwise indistinguishable from a broken one.
-          pointer-events:none on the wrapper (styles.css) so it never
-          intercepts panning/the double-click-to-create-node gesture on
-          .scene-canvas beneath it; the button itself opts back into
-          pointer-events so it stays clickable. */}
-      {scene.nodes.length === 0 && (
-        <div className="scene-empty-hint" role="status">
-          <p className="scene-empty-hint-text">Type a message to start, or load the sample workspace.</p>
-          <button type="button" className="scene-empty-hint-button" onClick={() => store.loadSampleWorkspace()}>
-            Load Sample Workspace
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/web_ui/src/app/chrome/ViewPopover.tsx
+++ b/web_ui/src/app/chrome/ViewPopover.tsx
@@ -111,12 +111,91 @@ function useDebouncedSetting<T>(remote: T, commit: (value: T) => void, delayMs =
   return [pending === null ? remote : pending, set] as const;
 }
 
-/** A slider header: what the value is, and what it currently reads. */
+/** A field header: what the setting is, and what it currently reads. */
 function FieldRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="view-field-row">
       <span className="view-field-label">{label}</span>
       <span className="view-field-value">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * A numeric setting: name, live value, one slider, and - where the backend
+ * publishes them - its landmark values as scale marks under the track.
+ *
+ * ONE CONTROL PER VALUE, which is the main thing this popover was missing.
+ * Pan speed and grid spacing each used to render a value badge, a slider,
+ * AND a four-button segmented control, all bound to the same number and
+ * stacked vertically: three representations of one setting, with nothing
+ * saying which was authoritative. That is a straight artifact of the port -
+ * the Qt controls offered presets, the SPA rewrite added sliders, and
+ * neither was taken away.
+ *
+ * The presets are worth keeping (they are the values the backend actually
+ * publishes as landmarks), so they stay - as small marks belonging to the
+ * slider's scale rather than as a competing control. Half the height, and
+ * no ambiguity about what sets the value.
+ *
+ * The track's fill is driven by --view-slider-fill rather than by a second
+ * element: a custom property set on the input inherits into the
+ * ::-webkit-slider-runnable-track pseudo-element, which is the only way to
+ * paint progress on a range input in this engine.
+ */
+function SliderField({
+  label,
+  ariaLabel,
+  value,
+  display,
+  min,
+  max,
+  presets,
+  formatPreset,
+  onInput,
+  onPreset,
+}: {
+  label: string;
+  ariaLabel: string;
+  value: number;
+  display: string;
+  min: number;
+  max: number;
+  presets?: readonly number[];
+  formatPreset?: (value: number) => string;
+  onInput: (value: number) => void;
+  onPreset?: (value: number) => void;
+}) {
+  const span = max - min;
+  const fill = span > 0 ? ((value - min) / span) * 100 : 0;
+  return (
+    <div className="view-field">
+      <FieldRow label={label} value={display} />
+      <input
+        type="range"
+        className="view-slider"
+        style={{ ["--view-slider-fill" as string]: `${Math.min(100, Math.max(0, fill))}%` }}
+        min={min}
+        max={max}
+        value={value}
+        aria-label={ariaLabel}
+        onChange={(e) => onInput(Number(e.target.value))}
+      />
+      {presets && presets.length > 0 && onPreset && (
+        <div className="view-ticks" role="group" aria-label={`${ariaLabel} presets`}>
+          {presets.map((preset) => (
+            <button
+              key={preset}
+              type="button"
+              className={"view-tick" + (preset === value ? " active" : "")}
+              aria-pressed={preset === value}
+              onClick={() => onPreset(preset)}
+            >
+              {formatPreset ? formatPreset(preset) : preset}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -201,15 +280,41 @@ function SwatchRow({
  * their presets (published by the backend), their intent names - instead of
  * three separately-positioned popover cards.
  *
- * Redesigned past the literal port: every slider carries a label and a live
- * value readout; grid style is a segmented control; the font family uses
- * the app's own CustomSelect (the component built precisely because bare
- * <select> was ruled off-idiom) with a live preview of the resulting node
- * typography; connection toggles live in their own CONNECTIONS section
- * rather than under GRID (an artifact of which Qt bridge happened to own
- * them); color rows gained a free-choice picker; the filter section grew
- * group labels and a clear affordance; and a footer resets everything to
- * the documented defaults.
+ * WHAT THIS PASS FIXED, and why it was there. The first version of this
+ * panel was a consolidation of three Qt islands, and it consolidated them
+ * additively: whatever each island had, plus whatever the SPA rewrite
+ * introduced, stacked in the order it was written. The result read as a
+ * port rather than as a panel.
+ *
+ * - DUPLICATE CONTROLS. Pan speed and grid spacing each rendered a value
+ *   badge, a slider, and a four-button segmented control - three
+ *   representations of one number, stacked. Grid style rendered its value
+ *   as a badge directly above a segmented control already showing it. Each
+ *   setting has one control now; the published landmark values live on the
+ *   slider's own scale (see SliderField).
+ * - READOUTS DRESSED AS BUTTONS. Every value badge was a bordered,
+ *   inset-filled pill - the exact shape of .view-chip, which IS a button.
+ *   They are plain tabular text now, aligned right, and nothing that cannot
+ *   be clicked looks like it can.
+ * - OS CHECKBOXES. The toggles were the one place in this panel wearing
+ *   engine chrome, next to a fully custom slider, segmented control and
+ *   swatch row.
+ * - A TRACK THAT SHOWED NOTHING. The slider's track was a single flat bar,
+ *   so the only cue for a value was thumb position; the track is filled to
+ *   the value now, which is what makes a row of sliders readable at a
+ *   glance.
+ * - SECTIONS BY BRIDGE, NOT BY MEANING. "Snap to Grid" and "Smart Guides"
+ *   are drag behaviours and sat under GRID (appearance) because the legacy
+ *   grid bridge happened to own their checkboxes - the same accident that
+ *   had already put the connection toggles there. They are in CANVAS now,
+ *   with the pan speed, which is where the rest of "how moving around
+ *   behaves" lives. "Focus Accepted Paths" was a one-toggle BRANCHES
+ *   section sitting immediately above FILTER while doing the same job as
+ *   it - dimming what you are not looking at - so it opens that section
+ *   instead of preceding it.
+ * - A FOOTER THAT SCROLLED AWAY. Reset to Defaults was the last thing in a
+ *   panel taller than the popover, so getting to it meant scrolling past
+ *   every control it undoes. It is pinned to the bottom.
  */
 export function ViewPopover({ store }: { store: SceneStore }) {
   const scene = useSyncExternalStore(store.subscribe, store.getScene);
@@ -266,223 +371,215 @@ export function ViewPopover({ store }: { store: SceneStore }) {
 
   return (
     <Popover name="view" label="View settings" className="view-popover" anchored>
-      <section className="view-section" aria-label="Canvas pan speed">
-        <p className="view-section-title">Navigation</p>
-        <FieldRow label="Canvas pan speed" value={`${dragPercent}%`} />
-        <input
-          type="range"
-          className="view-slider"
-          min={dragConfig.percentMin}
-          max={dragConfig.percentMax}
-          value={dragPercent}
-          aria-label="Canvas pan speed"
-          onChange={(e) => setDragPercent(Number(e.target.value))}
-        />
-        <div className="view-segment" role="group" aria-label="Drag speed presets">
-          {dragConfig.percentPresets.map((percent) => (
-            <button
-              key={percent}
-              type="button"
-              className={"view-segment-btn" + (percent === dragPercent ? " active" : "")}
-              aria-pressed={percent === dragPercent}
-              onClick={() => store.setDragFactor(percent / 100)}
-            >
-              {percent}%
-            </button>
-          ))}
-        </div>
-      </section>
+      <div className="view-scroll">
+        <section className="view-section" aria-label="Canvas">
+          <p className="view-section-title">Canvas</p>
+          <SliderField
+            label="Pan speed"
+            ariaLabel="Canvas pan speed"
+            value={dragPercent}
+            display={`${dragPercent}%`}
+            min={dragConfig.percentMin}
+            max={dragConfig.percentMax}
+            presets={dragConfig.percentPresets}
+            formatPreset={(p) => `${p}%`}
+            onInput={setDragPercent}
+            onPreset={(p) => store.setDragFactor(p / 100)}
+          />
+          <ToggleRow
+            label="Snap to Grid"
+            hint="Dragged nodes land on grid lines"
+            checked={scene.snapToGrid}
+            onChange={(v) => store.setSnapToGrid(v)}
+          />
+          <ToggleRow
+            label="Smart Guides"
+            hint="Snap to alignments with nearby nodes"
+            checked={scene.smartGuides}
+            onChange={(v) => store.setSmartGuides(v)}
+          />
+        </section>
 
-      <section className="view-section" aria-label="Grid">
-        <p className="view-section-title">Grid</p>
-        <FieldRow label="Spacing" value={`${gridSize}px`} />
-        <input
-          type="range"
-          className="view-slider"
-          min={GRID_SIZE_MIN}
-          max={GRID_SIZE_MAX}
-          value={gridSize}
-          aria-label="Grid spacing"
-          onChange={(e) => setGridSize(Number(e.target.value))}
-        />
-        <div className="view-segment" role="group" aria-label="Grid spacing presets">
-          {grid.sizePresets.map((size) => (
-            <button
-              key={size}
-              type="button"
-              className={"view-segment-btn" + (size === gridSize ? " active" : "")}
-              aria-pressed={size === gridSize}
-              onClick={() => store.setGridSize(size)}
-            >
-              {size}px
-            </button>
-          ))}
-        </div>
-        <FieldRow label="Opacity" value={`${gridOpacity}%`} />
-        <input
-          type="range"
-          className="view-slider"
-          min={0}
-          max={100}
-          value={gridOpacity}
-          aria-label="Grid opacity"
-          onChange={(e) => setGridOpacity(Number(e.target.value))}
-        />
-        <FieldRow label="Style" value={grid.gridStyle} />
-        <div className="view-segment" role="group" aria-label="Grid style">
-          {grid.stylePresets.map((style) => (
-            <button
-              key={style}
-              type="button"
-              className={"view-segment-btn" + (style === grid.gridStyle ? " active" : "")}
-              aria-pressed={style === grid.gridStyle}
-              onClick={() => store.setGridStyle(style)}
-            >
-              {style}
-            </button>
-          ))}
-        </div>
-        <FieldRow label="Color" value={gridColor.toUpperCase()} />
-        <SwatchRow
-          presets={grid.colorPresets}
-          current={gridColor}
-          ariaPrefix="Grid color"
-          onPick={setGridColor}
-        />
-        <ToggleRow
-          label="Snap to Grid"
-          hint="Dragged nodes land on grid lines"
-          checked={scene.snapToGrid}
-          onChange={(v) => store.setSnapToGrid(v)}
-        />
-        <ToggleRow
-          label="Smart Guides"
-          hint="Snap to alignments with nearby nodes"
-          checked={scene.smartGuides}
-          onChange={(v) => store.setSmartGuides(v)}
-        />
-      </section>
+        <section className="view-section" aria-label="Grid">
+          <p className="view-section-title">Grid</p>
+          <SliderField
+            label="Spacing"
+            ariaLabel="Grid spacing"
+            value={gridSize}
+            display={`${gridSize}px`}
+            min={GRID_SIZE_MIN}
+            max={GRID_SIZE_MAX}
+            presets={grid.sizePresets}
+            formatPreset={(s) => `${s}px`}
+            onInput={setGridSize}
+            onPreset={(s) => store.setGridSize(s)}
+          />
+          <SliderField
+            label="Opacity"
+            ariaLabel="Grid opacity"
+            value={gridOpacity}
+            display={`${gridOpacity}%`}
+            min={0}
+            max={100}
+            onInput={setGridOpacity}
+          />
+          {/* No value readout above this one: the segmented control IS the
+              readout - the selected segment says "Dots" as plainly as a
+              badge above it did. */}
+          <div className="view-field">
+            <span className="view-field-label">Style</span>
+            <div className="view-segment" role="group" aria-label="Grid style">
+              {grid.stylePresets.map((style) => (
+                <button
+                  key={style}
+                  type="button"
+                  className={"view-segment-btn" + (style === grid.gridStyle ? " active" : "")}
+                  aria-pressed={style === grid.gridStyle}
+                  onClick={() => store.setGridStyle(style)}
+                >
+                  {style}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="view-field">
+            <FieldRow label="Color" value={gridColor.toUpperCase()} />
+            <SwatchRow
+              presets={grid.colorPresets}
+              current={gridColor}
+              ariaPrefix="Grid color"
+              onPick={setGridColor}
+            />
+          </div>
+        </section>
 
-      {/* Fade/orthogonal lived under GRID in the straight port only because
-          the legacy grid-control bridge happened to own their checkboxes;
-          they configure connections, so they get a section that says so. */}
-      <section className="view-section" aria-label="Connections">
-        <p className="view-section-title">Connections</p>
-        <ToggleRow
-          label="Fade Connections"
-          hint="Dim all lines except the one under the pointer"
-          checked={scene.fadeConnectionsEnabled}
-          onChange={(v) => store.setFadeConnections(v)}
-        />
-        <ToggleRow
-          label="Orthogonal Routing"
-          hint="Route eligible lines at right angles"
-          checked={scene.orthogonalRouting}
-          onChange={(v) => store.setOrthogonalConnections(v)}
-        />
-      </section>
+        {/* Fade/orthogonal lived under GRID in the straight port only because
+            the legacy grid-control bridge happened to own their checkboxes;
+            they configure connections, so they get a section that says so. */}
+        <section className="view-section" aria-label="Connections">
+          <p className="view-section-title">Connections</p>
+          <ToggleRow
+            label="Fade Connections"
+            hint="Dim all lines except the one under the pointer"
+            checked={scene.fadeConnectionsEnabled}
+            onChange={(v) => store.setFadeConnections(v)}
+          />
+          <ToggleRow
+            label="Orthogonal Routing"
+            hint="Route eligible lines at right angles"
+            checked={scene.orthogonalRouting}
+            onChange={(v) => store.setOrthogonalConnections(v)}
+          />
+        </section>
 
-      <section className="view-section" aria-label="Font">
-        <p className="view-section-title">Node Font</p>
-        <CustomSelect
-          value={scene.fontFamily}
-          options={fontConfig.fontFamilies.map((family) => ({ id: family, label: family }))}
-          onChange={(family) => store.setFontFamily(family)}
-          ariaLabel="Font family"
-        />
-        <FieldRow label="Size" value={`${fontSizePt}pt`} />
-        <input
-          type="range"
-          className="view-slider"
-          min={fontConfig.sizeMin}
-          max={fontConfig.sizeMax}
-          value={fontSizePt}
-          aria-label="Font size"
-          onChange={(e) => setFontSizePt(Number(e.target.value))}
-        />
-        <FieldRow label="Color" value={fontColor.toUpperCase()} />
-        <SwatchRow
-          presets={fontConfig.colorPresets}
-          current={fontColor}
-          ariaPrefix="Font color"
-          onPick={setFontColor}
-        />
-        {/* What the settings above actually produce on a node card - the
-            readout the three separate controls never had. */}
-        <div
-          className="view-font-preview"
-          aria-hidden="true"
-          style={{
-            fontFamily: scene.fontFamily,
-            fontSize: `${fontSizePt}pt`,
-            color: fontColor,
-          }}
-        >
-          The quick brown fox jumps over the lazy dog
-        </div>
-      </section>
+        <section className="view-section" aria-label="Node font">
+          <p className="view-section-title">Node Font</p>
+          <div className="view-field">
+            <span className="view-field-label">Family</span>
+            <CustomSelect
+              value={scene.fontFamily}
+              options={fontConfig.fontFamilies.map((family) => ({ id: family, label: family }))}
+              onChange={(family) => store.setFontFamily(family)}
+              ariaLabel="Font family"
+            />
+          </div>
+          <SliderField
+            label="Size"
+            ariaLabel="Font size"
+            value={fontSizePt}
+            display={`${fontSizePt}pt`}
+            min={fontConfig.sizeMin}
+            max={fontConfig.sizeMax}
+            onInput={setFontSizePt}
+          />
+          <div className="view-field">
+            <FieldRow label="Color" value={fontColor.toUpperCase()} />
+            <SwatchRow
+              presets={fontConfig.colorPresets}
+              current={fontColor}
+              ariaPrefix="Font color"
+              onPick={setFontColor}
+            />
+          </div>
+          {/* What the settings above actually produce on a node card - the
+              readout the three separate controls never had. */}
+          <div
+            className="view-font-preview"
+            aria-hidden="true"
+            style={{
+              fontFamily: scene.fontFamily,
+              fontSize: `${fontSizePt}pt`,
+              color: fontColor,
+            }}
+          >
+            The quick brown fox jumps over the lazy dog
+          </div>
+        </section>
 
-      <section className="view-section" aria-label="Branches">
-        <p className="view-section-title">Branches</p>
-        {/* ADR-002 Workstream 1 ("Branch status and lifecycle"): dims every
-            node outside the accepted paths (rejected/superseded branches
-            and their descendants, unless an explicit "accepted" override
-            reactivates a sub-branch) - the whole-graph counterpart to a
-            single chat node's own "Hide Other Branches" menu action.
-            Backed by sceneStore's own local focusAcceptedPaths field
-            rather than `scene` - see that field's own comment. */}
-        <ToggleRow
-          label="Focus Accepted Paths"
-          hint="Dim rejected and superseded branches"
-          checked={focusAcceptedPaths}
-          onChange={(v) => store.setFocusAcceptedPaths(v)}
-        />
-      </section>
+        <section className="view-section" aria-label="Focus">
+          <div className="view-section-head">
+            <p className="view-section-title">Focus</p>
+            {filterCount > 0 && (
+              <button type="button" className="view-clear-btn" onClick={() => store.clearFilters()}>
+                Clear ({filterCount})
+              </button>
+            )}
+          </div>
+          {/* ADR-002 Workstream 1 ("Branch status and lifecycle"): dims every
+              node outside the accepted paths (rejected/superseded branches
+              and their descendants, unless an explicit "accepted" override
+              reactivates a sub-branch) - the whole-graph counterpart to a
+              single chat node's own "Hide Other Branches" menu action.
+              Backed by sceneStore's own local focusAcceptedPaths field
+              rather than `scene` - see that field's own comment. It opens
+              this section rather than owning a one-toggle section of its
+              own directly above it: dimming rejected branches and dimming
+              filtered-out kinds are the same job. */}
+          <ToggleRow
+            label="Focus Accepted Paths"
+            hint="Dim rejected and superseded branches"
+            checked={focusAcceptedPaths}
+            onChange={(v) => store.setFocusAcceptedPaths(v)}
+          />
+          {/* ADR-012 stage 12.5: multi-select toggle chips - "active" means
+              "toggled into the filter set," not mutual exclusion; a click
+              only ever flips ITS OWN membership in sceneStore's filterKinds/
+              filterStatuses Sets. An empty set (no chip active) means no
+              filter at all - every node shows at full opacity. */}
+          <p className="view-subsection-title">By kind</p>
+          <div className="view-row" role="group" aria-label="Filter by node kind">
+            {FILTERABLE_NODE_KINDS.map((kind) => (
+              <button
+                key={kind}
+                type="button"
+                className={"view-chip" + (filterKinds.has(kind) ? " active" : "")}
+                aria-pressed={filterKinds.has(kind)}
+                onClick={() => store.toggleFilterKind(kind)}
+              >
+                {FILTER_KIND_LABELS[kind]}
+              </button>
+            ))}
+          </div>
+          <p className="view-subsection-title">By branch status</p>
+          <div className="view-row" role="group" aria-label="Filter by branch status">
+            {FILTER_STATUS_VALUES.map((status) => (
+              <button
+                key={status}
+                type="button"
+                className={"view-chip" + (filterStatuses.has(status) ? " active" : "")}
+                aria-pressed={filterStatuses.has(status)}
+                onClick={() => store.toggleFilterStatus(status)}
+              >
+                {FILTER_STATUS_LABELS[status]}
+              </button>
+            ))}
+          </div>
+        </section>
+      </div>
 
-      <section className="view-section" aria-label="Filter">
-        <div className="view-section-head">
-          <p className="view-section-title">Filter</p>
-          {filterCount > 0 && (
-            <button type="button" className="view-clear-btn" onClick={() => store.clearFilters()}>
-              Clear ({filterCount})
-            </button>
-          )}
-        </div>
-        {/* ADR-012 stage 12.5: multi-select toggle chips - "active" means
-            "toggled into the filter set," not mutual exclusion; a click
-            only ever flips ITS OWN membership in sceneStore's filterKinds/
-            filterStatuses Sets. An empty set (no chip active) means no
-            filter at all - every node shows at full opacity. */}
-        <p className="view-subsection-title">By kind</p>
-        <div className="view-row" role="group" aria-label="Filter by node kind">
-          {FILTERABLE_NODE_KINDS.map((kind) => (
-            <button
-              key={kind}
-              type="button"
-              className={"view-chip" + (filterKinds.has(kind) ? " active" : "")}
-              aria-pressed={filterKinds.has(kind)}
-              onClick={() => store.toggleFilterKind(kind)}
-            >
-              {FILTER_KIND_LABELS[kind]}
-            </button>
-          ))}
-        </div>
-        <p className="view-subsection-title">By branch status</p>
-        <div className="view-row" role="group" aria-label="Filter by branch status">
-          {FILTER_STATUS_VALUES.map((status) => (
-            <button
-              key={status}
-              type="button"
-              className={"view-chip" + (filterStatuses.has(status) ? " active" : "")}
-              aria-pressed={filterStatuses.has(status)}
-              onClick={() => store.toggleFilterStatus(status)}
-            >
-              {FILTER_STATUS_LABELS[status]}
-            </button>
-          ))}
-        </div>
-      </section>
-
+      {/* Outside .view-scroll on purpose: the panel is taller than the
+          popover, and a footer inside the scroller means scrolling past
+          every control this button undoes in order to reach it. */}
       <div className="view-footer">
         <button type="button" className="view-reset-btn" onClick={resetAll}>
           Reset to Defaults

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -251,52 +251,6 @@ body,
   background-color: var(--gl-surface-window);
 }
 
-/* ADR-012 stage 12.6: the empty-canvas hint - a fresh session's blank scene
-   otherwise looks indistinguishable from a broken one. Centered flex column
-   over the full canvas, same layout shape as .scene-bridge-error above (a
-   proven "replace/annotate the whole canvas region" pattern in this file),
-   but layered ON TOP of a working canvas rather than instead of a broken
-   one, so pointer-events is none on the wrapper - panning/the double-click-
-   to-create-node gesture on .scene-canvas underneath must keep working -
-   with only the button itself opting back in so it stays clickable. */
-.scene-empty-hint {
-  position: absolute;
-  inset: 0;
-  z-index: var(--gl-z-canvas-hud);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  padding: 32px;
-  text-align: center;
-  pointer-events: none;
-}
-
-.scene-empty-hint-text {
-  margin: 0;
-  max-width: 360px;
-  font-size: 13px;
-  color: var(--gl-surface-text-muted);
-}
-
-.scene-empty-hint-button {
-  padding: 6px 14px;
-  font-size: 12px;
-  font-weight: 600;
-  font-family: inherit;
-  color: var(--gl-surface-text-primary);
-  background-color: var(--gl-neutral-button-background);
-  border: 1px solid var(--gl-neutral-button-border);
-  border-radius: 6px;
-  cursor: pointer;
-  pointer-events: auto;
-}
-
-.scene-empty-hint-button:hover {
-  border-color: var(--gl-surface-border-strong, var(--gl-surface-text-muted));
-}
-
 .scene-node {
   min-width: 160px;
   background-color: var(--gl-surface-node-body);

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1998,22 +1998,68 @@ body,
   text-align: center;
 }
 
-/* -- View popover -------------------------------------------------------- */
+/* -- View popover ---------------------------------------------------------
+
+   A settings PANEL that opens as a popover, which is what its layout has to
+   admit: five sections and roughly twenty-five controls, taller than the
+   popover can be at any window size. So it is built as a fixed shell - a
+   scrolling body with a pinned footer - rather than as one long scrolling
+   block with the reset button stranded at the end of it.
+
+   ONE SPACING SCALE, and only one, because the absence of one is most of
+   what read as sloppy here: 6px inside a field (its label to its control),
+   12px between fields, 16px plus a rule between sections. Every element
+   used to carry its own margin - 10 above a field row, 4 below a slider, 6
+   above a segment, 10 above a toggle - so nothing lined up with anything
+   and no gap meant the same thing twice. The rhythm is now a single owl
+   rule on .view-section with two documented exceptions. */
 
 .view-popover {
   width: 300px;
   max-height: min(72vh, 720px);
+  display: flex;
+  flex-direction: column;
+  /* Padding moves to the scroller and the footer so the footer's rule can
+     span the full panel width, and overflow moves to the scroller so the
+     footer stays put. Both override .overlay-popover's own defaults, which
+     they can: this rule is later in the file. */
+  padding: 0;
+  overflow: hidden;
+}
+
+.view-scroll {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
+  padding: 12px 14px;
 }
 
 .view-section + .view-section {
-  margin-top: 14px;
-  padding-top: 12px;
+  margin-top: 16px;
+  padding-top: 14px;
   border-top: 1px solid var(--gl-surface-border);
 }
 
+/* The one rhythm rule. Fields, toggles and rows all inherit it; the two
+   exceptions below are places where a tighter pairing is the point.
+
+   The margin RESET is half the rule and has to live here rather than on
+   each child: `.view-section > * + *` and a bare `.view-subsection-title`
+   have identical specificity, so a `margin: 0` written on the child
+   silently cancelled the 12px for that child alone - which is exactly what
+   happened to the filter sub-headings, leaving them jammed against the
+   toggle above them while every other gap was correct. Zeroing every
+   child's UA margin up front, in the same rule that then adds the gap back,
+   removes the whole class of tie. */
+.view-section > * {
+  margin: 0;
+}
+
+.view-section > * + * {
+  margin-top: 12px;
+}
+
 .view-section-title {
-  margin: 0 0 8px;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.14em;
@@ -2024,28 +2070,39 @@ body,
 /* Section header that also carries an action (the filter Clear button). */
 .view-section-head {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
+  gap: 8px;
 }
 
 .view-subsection-title {
-  margin: 10px 0 4px;
   font-size: 10px;
   font-weight: 600;
+  letter-spacing: 0.04em;
   color: var(--gl-surface-text-label);
 }
 
-/* Label + live value readout above every slider - the redesign's core
-   idiom: no control without a name and a current value. */
+/* Exception 1: a sub-heading belongs to the row under it, not to the gap
+   above it. */
+.view-subsection-title + .view-row {
+  margin-top: 6px;
+}
+
+/* A field is one setting: its header, its control, and any scale marks
+   belonging to that control. Grouping them in an element is what lets the
+   rhythm rule above treat a whole setting as one unit. */
+.view-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* Label + live value readout above a control. */
 .view-field-row {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  margin-top: 10px;
-}
-
-.view-field-row:first-of-type {
-  margin-top: 0;
+  gap: 8px;
 }
 
 .view-field-label {
@@ -2053,15 +2110,19 @@ body,
   color: var(--gl-surface-text-secondary);
 }
 
+/* Exception 2: plain text, deliberately. This was a bordered, inset-filled
+   999px pill - pixel for pixel the shape of .view-chip, which is a BUTTON.
+   A read-only number that looks clickable is worse than an unstyled one, so
+   the readout now carries only what a readout needs: alignment, tabular
+   figures so it stops jittering as a slider moves, and enough contrast to
+   be the answer to "what is this set to". */
 .view-field-value {
-  font-size: 10px;
+  font-size: 10.5px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  padding: 1px 6px;
+  letter-spacing: 0.02em;
   color: var(--gl-surface-text-primary);
-  background-color: var(--gl-surface-inset);
-  border: 1px solid var(--gl-surface-border);
-  border-radius: 999px;
+  white-space: nowrap;
 }
 
 /* Sliders: styled track/thumb rather than the engine default, which reads
@@ -2071,31 +2132,43 @@ body,
   -webkit-appearance: none;
   appearance: none;
   width: 100%;
-  height: 18px;
-  margin: 4px 0 2px;
+  height: 14px;
+  margin: 0;
   background: transparent;
   cursor: pointer;
 }
 
+/* The track is FILLED to the current value. It used to be one flat bar, so
+   the only cue for where a setting sat was the thumb's position against
+   nothing - fine for one slider, unreadable for a column of them. The fill
+   width arrives as --view-slider-fill, set inline on the input by
+   SliderField: a custom property set on the input inherits into this
+   pseudo-element, which is the only way to paint progress on a range input
+   in this engine. */
 .view-slider::-webkit-slider-runnable-track {
   height: 4px;
-  border-radius: 2px;
-  background-color: var(--gl-neutral-button-border);
+  border-radius: 999px;
+  background-image: linear-gradient(
+    to right,
+    var(--gl-surface-text-secondary) 0 var(--view-slider-fill, 0%),
+    var(--gl-neutral-button-border) var(--view-slider-fill, 0%) 100%
+  );
 }
 
 .view-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 14px;
-  height: 14px;
-  margin-top: -5px;
+  width: 12px;
+  height: 12px;
+  margin-top: -4px;
   border-radius: 50%;
   background-color: var(--gl-surface-text-primary);
   border: 1px solid var(--gl-surface-border-strong);
   transition: transform var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
-.view-slider::-webkit-slider-thumb:hover {
+.view-slider:hover::-webkit-slider-thumb,
+.view-slider:focus-visible::-webkit-slider-thumb {
   transform: scale(1.15);
 }
 
@@ -2105,8 +2178,47 @@ body,
   border-radius: 4px;
 }
 
-/* Segmented control: one connected group for mutually-exclusive choices
-   (grid style, spacing presets, drag presets), replacing loose buttons. */
+/* The landmark values the backend publishes for a slider, drawn as marks on
+   that slider's own scale. They were a four-button segmented control
+   underneath the slider - a second, differently-shaped widget bound to the
+   same number, which is what made pan speed and grid spacing read as three
+   controls for one setting. As text marks they still set the value on
+   click, at a third of the height, and they read as part of the slider
+   rather than as a rival to it. */
+.view-ticks {
+  display: flex;
+  justify-content: space-between;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.view-tick {
+  font-size: 10px;
+  font-weight: 600;
+  font-family: inherit;
+  font-variant-numeric: tabular-nums;
+  padding: 0;
+  color: var(--gl-surface-text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color var(--gl-motion-fast) var(--gl-motion-ease);
+}
+
+.view-tick:hover {
+  color: var(--gl-surface-text-primary);
+}
+
+.view-tick.active {
+  color: var(--gl-surface-text-bright);
+}
+
+.view-tick:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
 /* A segmented control: a recessed track with one raised, selected segment.
    The track is what makes the selection readable - previously every segment
    carried the same --gl-neutral-button-background fill and the selected one
@@ -2117,7 +2229,6 @@ body,
    track -> hover -> selected. */
 .view-segment {
   display: flex;
-  margin-top: 6px;
   background-color: var(--gl-surface-inset);
   border: 1px solid var(--gl-neutral-button-border);
   border-radius: 6px;
@@ -2162,7 +2273,6 @@ body,
 .view-row {
   display: flex;
   gap: 4px;
-  margin-top: 6px;
   flex-wrap: wrap;
 }
 
@@ -2173,27 +2283,42 @@ body,
    (grid style, preset values) and is drawn as one connected control.
    Chips carry no single/multi-select meaning of their own: the filters
    are multi-select, the workspace tabs single-select, and both read
-   correctly because an active chip simply means "this one is on". */
+   correctly because an active chip simply means "this one is on".
+
+   Same inverted scale the segmented control had, and the same fix: active
+   was --gl-neutral-button-pressed, a step DARKER than the idle fill, so a
+   selected chip was the dimmest chip in the row and hovering an unselected
+   one lit it brighter than the selection. Idle -> hover -> active now steps
+   one way on both palettes. */
 .view-chip {
   font-size: 10px;
   font-weight: 600;
   font-family: inherit;
   padding: 3px 9px;
   color: var(--gl-surface-text-secondary);
-  background-color: var(--gl-neutral-button-background);
-  border: 1px solid var(--gl-neutral-button-border);
+  background-color: transparent;
+  border: 1px solid var(--gl-surface-border);
   border-radius: 999px;
   cursor: pointer;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    border-color var(--gl-motion-fast) var(--gl-motion-ease),
+    color var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
 .view-chip:hover {
-  background-color: var(--gl-neutral-button-hover);
+  background-color: var(--gl-neutral-button-background);
   color: var(--gl-surface-text-primary);
 }
 
+.view-chip:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 1px;
+}
+
 .view-chip.active {
-  background-color: var(--gl-neutral-button-pressed, var(--gl-neutral-button-hover));
-  border-color: var(--gl-surface-text-muted);
+  background-color: var(--gl-neutral-button-hover);
+  border-color: var(--gl-neutral-button-border);
   color: var(--gl-surface-text-bright);
 }
 
@@ -2201,17 +2326,23 @@ body,
   font-size: 10px;
   font-weight: 600;
   font-family: inherit;
-  padding: 1px 8px;
+  padding: 2px 8px;
   color: var(--gl-surface-text-secondary);
   background: none;
-  border: 1px solid var(--gl-neutral-button-border);
+  border: 1px solid var(--gl-surface-border);
   border-radius: 999px;
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .view-clear-btn:hover {
   color: var(--gl-surface-text-primary);
-  background-color: var(--gl-neutral-button-hover);
+  background-color: var(--gl-neutral-button-background);
+}
+
+.view-clear-btn:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 1px;
 }
 
 .view-color-swatch {
@@ -2229,6 +2360,11 @@ body,
    state. */
 .view-color-swatch:hover {
   border-color: var(--gl-surface-text-muted);
+}
+
+.view-color-swatch:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 2px;
 }
 
 .view-color-swatch.active {
@@ -2282,21 +2418,63 @@ body,
 .view-toggle-row {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  margin-top: 10px;
+  gap: 9px;
   cursor: pointer;
 }
 
+/* A drawn checkbox. These were the last engine-drawn controls in the panel:
+   an OS checkbox sitting beside a custom slider, a custom segmented control
+   and a custom swatch row, with `accent-color` doing what it could. The
+   native input stays - every bit of its keyboard and screen-reader
+   behaviour with it - and only the paint job is replaced. */
 .view-toggle-row input[type="checkbox"] {
+  appearance: none;
+  position: relative;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
   margin: 1px 0 0;
-  accent-color: var(--gl-surface-text-primary);
+  background: transparent;
+  border: 1px solid var(--gl-surface-border-strong);
+  border-radius: 4px;
   cursor: pointer;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    border-color var(--gl-motion-fast) var(--gl-motion-ease);
+}
+
+.view-toggle-row:hover input[type="checkbox"]:not(:checked) {
+  border-color: var(--gl-surface-text-muted);
+}
+
+.view-toggle-row input[type="checkbox"]:checked {
+  background-color: var(--gl-surface-text-primary);
+  border-color: var(--gl-surface-text-primary);
+}
+
+/* The tick, drawn from two borders on a rotated box - no glyph, so it
+   cannot pick up a fallback font's own idea of what a checkmark is. */
+.view-toggle-row input[type="checkbox"]:checked::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 3px;
+  height: 7px;
+  border: solid var(--gl-surface-window);
+  border-width: 0 1.6px 1.6px 0;
+  transform: rotate(45deg);
+}
+
+.view-toggle-row input[type="checkbox"]:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 2px;
 }
 
 .view-toggle-text {
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 2px;
 }
 
 .view-toggle-label {
@@ -2306,6 +2484,7 @@ body,
 
 .view-toggle-hint {
   font-size: 10px;
+  line-height: 1.4;
   color: var(--gl-surface-text-muted);
 }
 
@@ -2313,7 +2492,6 @@ body,
    the node card's own tokens so the sample sits on the same background the
    text will actually be read against. */
 .view-font-preview {
-  margin-top: 8px;
   padding: 8px 10px;
   background-color: var(--gl-surface-node-body);
   border: 1px solid var(--gl-surface-border);
@@ -2323,10 +2501,14 @@ body,
   white-space: nowrap;
 }
 
+/* Pinned, not trailing. This panel is taller than the popover at every
+   window size, so a footer inside the scroller meant scrolling past all
+   twenty-five controls to reach the one button that undoes them. */
 .view-footer {
-  margin-top: 14px;
-  padding-top: 12px;
+  flex-shrink: 0;
+  padding: 10px 14px;
   border-top: 1px solid var(--gl-surface-border);
+  background-color: var(--gl-surface-node-body);
 }
 
 .view-reset-btn {
@@ -2336,15 +2518,23 @@ body,
   font-family: inherit;
   padding: 6px 0;
   color: var(--gl-surface-text-secondary);
-  background-color: var(--gl-neutral-button-background);
-  border: 1px solid var(--gl-neutral-button-border);
+  background-color: transparent;
+  border: 1px solid var(--gl-surface-border);
   border-radius: 6px;
   cursor: pointer;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    color var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
 .view-reset-btn:hover {
-  background-color: var(--gl-neutral-button-hover);
+  background-color: var(--gl-neutral-button-background);
   color: var(--gl-surface-text-primary);
+}
+
+.view-reset-btn:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 1px;
 }
 
 /* -- R2.3 composer + token counter + notification ------------------------ */


### PR DESCRIPTION
## Problem

**Empty-canvas overlay.** ADR-012 stage 12.6 added a full-canvas hint on an empty scene ("Type a message to start, or load the sample workspace" plus a Load Sample Workspace button). It was painted at `--gl-z-canvas-hud` (21), a tier intended for the token counter and minimap, which each occupy one screen corner. The overlay was `position: absolute; inset: 0`, so it covered the whole canvas at a tier above `--gl-z-app-layer` (20) - every popover anchored over the canvas, including View, Plugins and Pins. Its text and button drew on top of them whenever the scene was empty.

**View panel.** The panel consolidated three Qt islands additively, and retained every control from each:

- Pan speed rendered a value badge, a slider and a four-button segmented control, all bound to the same value. Grid spacing did the same. Grid style rendered a value badge above a segmented control already showing that value.
- Value badges were bordered, inset-filled 999px pills - the same shape as `.view-chip`, which is a button.
- Element margins were set individually (10 above a field row, 4 below a slider, 6 above a segment, 10 above a toggle), so gap size carried no consistent meaning.
- The slider track was a single flat bar; value was indicated only by thumb position.
- Toggles used engine-drawn checkboxes alongside a custom slider, segmented control and swatch row.
- "Snap to Grid" and "Smart Guides" are drag behaviours and sat under GRID. "Focus Accepted Paths" was a one-toggle BRANCHES section directly above FILTER.
- Reset to Defaults was the last element inside the scroller, in a panel taller than the popover at every window size.
- `.view-chip.active` used `--gl-neutral-button-pressed`, darker than the idle fill on the dark palette, so a selected chip was the dimmest in the row. Shared with the Chat Library's workspace tabs and tag filters.

## Change

**Overlay removed** rather than re-tiered. `loadSampleWorkspace` intent and store method are unchanged; OnboardingDialog still offers it. Three E2E specs referenced the overlay: `boot.spec` used its visibility as a proxy for "zero nodes" and now asserts that directly; `create-node` and `workspace-save-reload` keep their corner-offset dblclicks with corrected comments.

**View panel:**

- One control per value. Backend-published landmark values render as marks on the slider scale.
- Value readouts are plain right-aligned tabular text.
- One spacing scale: 6px within a field, 12px between fields, 16px and a rule between sections. The margin reset lives in the same rule as the gap, since a `margin: 0` on a child ties on specificity and cancels it.
- Slider track fills to the current value via a custom property inherited into `::-webkit-slider-runnable-track`.
- Checkboxes restyled; the native input and its behaviour are retained.
- Sections re-cut to Canvas, Grid, Connections, Node Font, Focus. Six sections become five.
- Panel is a fixed shell: scrolling body, pinned footer.
- `.view-chip` idle/hover/active now step in one direction on both palettes.

## Test plan

- `ViewPopover.test.tsx`: 14 pass, unchanged. Accessible names are preserved through the restructure.
- `SceneCanvas.test.tsx`: 179 pass. Three overlay tests replaced with one reintroduction guard.
- `npm run check` (schema drift, typecheck, lint, vitest, build, bundle size) against a clean checkout of this branch.
- Spacing verified against the live DOM: every section reads 0, 12, 12, 12 with the two intended 6px sub-heading pairings. Confirmed the popover is `padding: 0; overflow: hidden` with scroll and padding on the body, footer at `flex-shrink: 0`, readout with no border or background, checkbox at `appearance: none`.
