### PR TITLE
Correct and rewrite the Help panel content

### DIFF
--- a/web_ui/e2e/boot.spec.ts
+++ b/web_ui/e2e/boot.spec.ts
@@ -33,8 +33,10 @@ test("boots against the real backend and renders the canvas shell", async ({ pag
   // has no visible text to check on the happy path this test exercises.
   await expect(page.locator('.app-shell[data-connection-status="open"]')).toBeAttached();
 
-  // A fresh session has zero nodes - SceneCanvas.tsx's own empty-state hint
-  // is the honest "nothing broken, genuinely nothing here yet" signal for
-  // that case (see its own comment on why this exists at all).
-  await expect(page.locator(".scene-empty-hint")).toBeVisible();
+  // A fresh session has zero nodes, and that is asserted directly now. It
+  // used to be asserted through SceneCanvas.tsx's empty-canvas hint - a
+  // full-canvas overlay that has since been removed for painting itself
+  // over every popover anchored on the canvas. An empty canvas is the state
+  // this line was always about; the overlay was only ever a proxy for it.
+  await expect(page.locator(".react-flow__node")).toHaveCount(0);
 });

--- a/web_ui/e2e/create-node.spec.ts
+++ b/web_ui/e2e/create-node.spec.ts
@@ -33,11 +33,13 @@ test("creates a node by double-click, then a Conversation Node via the Plugins p
   const canvas = page.getByTestId("scene-canvas");
   const box = await canvas.boundingBox();
   if (!box) throw new Error("scene-canvas has no layout box to click into");
-  // Deliberately NOT the canvas's exact center: SceneCanvas.tsx's own empty-
-  // state hint (".scene-empty-hint", styles.css) is centered with `inset: 0`
-  // + flexbox centering and stays mounted until the first node exists - a
-  // dblclick at width/2,height/2 lands ON its real "Load Sample Workspace"
-  // button instead of blank canvas. A corner offset stays clear of it.
+  // A corner offset rather than the canvas's exact center. This used to be
+  // load-bearing: a full-canvas empty-state hint was centered over the
+  // canvas until the first node existed, so a dblclick at width/2,height/2
+  // landed on its "Load Sample Workspace" button instead of blank canvas.
+  // That overlay is gone, so any point on the canvas would do now - the
+  // offset is kept because the exact coordinates are arbitrary either way
+  // and moving them would churn a passing test for nothing.
   await canvas.dblclick({ position: { x: box.width * 0.15, y: box.height * 0.15 } });
 
   await expect(page.locator(".react-flow__node")).toHaveCount(1);

--- a/web_ui/e2e/workspace-save-reload.spec.ts
+++ b/web_ui/e2e/workspace-save-reload.spec.ts
@@ -62,10 +62,10 @@ test("saves a node, clears the canvas, then reloads it from the chat library", a
   const canvas = page.getByTestId("scene-canvas");
   const box = await canvas.boundingBox();
   if (!box) throw new Error("scene-canvas has no layout box to click into");
-  // Off-center on purpose - see create-node.spec.ts's own comment: a click
-  // at the exact center lands on the empty-state hint's real "Load Sample
-  // Workspace" button (styles.css's ".scene-empty-hint" is centered with
-  // `inset: 0`) rather than blank canvas.
+  // A corner offset rather than the exact center - see create-node.spec.ts's
+  // own comment. It used to be dodging the empty-state hint's "Load Sample
+  // Workspace" button; that overlay is gone, and the offset is kept only
+  // because the coordinates are arbitrary either way.
   await canvas.dblclick({ position: { x: box.width * 0.15, y: box.height * 0.15 } });
   await expect(page.locator(".react-flow__node")).toHaveCount(1);
 

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -3109,14 +3109,13 @@ describe("SceneCanvas version-rejection gate (ADR-003 stage 3.5)", () => {
   });
 });
 
-describe("SceneCanvas empty-canvas hint (ADR-012 stage 12.6)", () => {
+describe("SceneCanvas empty canvas", () => {
   type StateListener = (payload: Record<string, unknown>) => void;
 
   // Same minimal transport shape as makeStoreWithVersionControl above (a
   // sibling, not reused, since it is scoped to that describe block) - just
-  // enough of WsTransport's surface for SceneCanvas to mount and for a test
-  // to push a real scene snapshot afterward.
-  function makeStoreForEmptyHint() {
+  // enough of WsTransport's surface for SceneCanvas to mount.
+  function makeStoreForEmptyCanvas() {
     const stateListeners = new Map<string, StateListener>();
     const transport = {
       subscribe: vi.fn((topic: string, listener: StateListener) => {
@@ -3137,42 +3136,21 @@ describe("SceneCanvas empty-canvas hint (ADR-012 stage 12.6)", () => {
     return { store, transport, stateListeners };
   }
 
-  const HINT_TEXT = "Type a message to start, or load the sample workspace.";
-
-  it("renders the empty-canvas hint when the scene has no nodes", () => {
-    const { store } = makeStoreForEmptyHint();
-
-    render(
-      <ReactFlowProvider>
-        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
-      </ReactFlowProvider>,
-    );
-
-    expect(screen.getByText(HINT_TEXT)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Load Sample Workspace" })).toBeInTheDocument();
-  });
-
-  it("hides the empty-canvas hint once the scene has a real node", () => {
-    const { store, stateListeners } = makeStoreForEmptyHint();
-
-    render(
-      <ReactFlowProvider>
-        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
-      </ReactFlowProvider>,
-    );
-    expect(screen.getByText(HINT_TEXT)).toBeInTheDocument();
-
-    act(() => {
-      stateListeners.get("scene")!(
-        baseScene({ nodes: [baseNode({ id: "n1" })] }) as unknown as Record<string, unknown>,
-      );
-    });
-
-    expect(screen.queryByText(HINT_TEXT)).toBeNull();
-  });
-
-  it("the Load Sample Workspace button fires the scene-topic loadSampleWorkspace intent", () => {
-    const { store, transport } = makeStoreForEmptyHint();
+  // ADR-012 stage 12.6 added a full-canvas "Type a message to start, or load
+  // the sample workspace" overlay with a Load Sample Workspace button. It is
+  // gone, and this is the guard against it coming back.
+  //
+  // It was not merely unwanted - it was painted at --gl-z-canvas-hud (21),
+  // the tier reserved for the token counter and the minimap, which each own
+  // a screen CORNER. This overlay was `position: absolute; inset: 0`, so it
+  // claimed the whole canvas at a tier ABOVE --gl-z-app-layer (20) - every
+  // popover anchored over the canvas, View and Plugins and Pins included.
+  // Its text and its button painted straight through all of them.
+  //
+  // The loadSampleWorkspace intent itself is untouched: OnboardingDialog
+  // still offers it, in a dialog, where a first-run affordance belongs.
+  it("renders no overlay on an empty scene - no hint text, no button over the canvas", () => {
+    const { store } = makeStoreForEmptyCanvas();
 
     render(
       <ReactFlowProvider>
@@ -3180,7 +3158,8 @@ describe("SceneCanvas empty-canvas hint (ADR-012 stage 12.6)", () => {
       </ReactFlowProvider>,
     );
 
-    screen.getByRole("button", { name: "Load Sample Workspace" }).click();
-    expect(transport.fireIntent).toHaveBeenCalledWith("scene", "loadSampleWorkspace", []);
+    expect(screen.queryByText(/load the sample workspace/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Load Sample Workspace" })).toBeNull();
+    expect(document.querySelector(".scene-empty-hint")).toBeNull();
   });
 });

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -2856,20 +2856,6 @@ function CanvasInner({
           </ViewportPortal>
         )}
       </ReactFlow>
-      {/* ADR-012 stage 12.6: a non-blank empty-canvas hint - a fresh
-          session's scene is otherwise indistinguishable from a broken one.
-          pointer-events:none on the wrapper (styles.css) so it never
-          intercepts panning/the double-click-to-create-node gesture on
-          .scene-canvas beneath it; the button itself opts back into
-          pointer-events so it stays clickable. */}
-      {scene.nodes.length === 0 && (
-        <div className="scene-empty-hint" role="status">
-          <p className="scene-empty-hint-text">Type a message to start, or load the sample workspace.</p>
-          <button type="button" className="scene-empty-hint-button" onClick={() => store.loadSampleWorkspace()}>
-            Load Sample Workspace
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/web_ui/src/app/chrome/HelpDialog.test.tsx
+++ b/web_ui/src/app/chrome/HelpDialog.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { HelpDialog } from "./HelpDialog";
+import { HELP_SECTIONS } from "./help-data/sections";
+import { resolveShortcut, type ShortcutId, type ShortcutKeyEvent } from "./shortcuts";
+import { OverlayProvider, useOverlays } from "../overlays/overlays";
+
+/**
+ * The Help panel had no tests at all, which is how it drifted: an audit
+ * found it describing a "Controls toggle" renamed to View, a Shift-drag
+ * zoom gesture that had become rubber-band selection, and a plugin under a
+ * name the picker no longer used. Prose cannot be type-checked, so most of
+ * that class of rot is only catchable by a human reading the app and the
+ * copy side by side.
+ *
+ * One slice of it CAN be pinned mechanically, and it is the slice readers
+ * trust most literally: the key chords. The suite below parses every chord
+ * out of the content and feeds it to the real resolveShortcut() - the same
+ * function GlobalShortcuts dispatches on - so the day a binding moves, Help
+ * fails a test instead of lying to somebody.
+ */
+
+function OpenHelpOnMount({ children }: { children: React.ReactNode }) {
+  const overlays = useOverlays();
+  if (!overlays.isOpen("help")) overlays.open("help", "dialog");
+  return <>{children}</>;
+}
+
+function renderOpen() {
+  return render(
+    <OverlayProvider>
+      <OpenHelpOnMount>
+        <HelpDialog />
+      </OpenHelpOnMount>
+    </OverlayProvider>,
+  );
+}
+
+const allItems = HELP_SECTIONS.flatMap((section) =>
+  section.subsections.flatMap((subsection) =>
+    subsection.items.map((item) => ({ section, subsection, item })),
+  ),
+);
+
+/** "Ctrl+Shift+Z" -> the event GlobalShortcuts would see. */
+function chordToEvent(chord: string): ShortcutKeyEvent {
+  const parts = chord.split("+").map((p) => p.trim());
+  const key = parts[parts.length - 1];
+  const named: Record<string, string> = { "←": "ArrowLeft", "→": "ArrowRight", "↑": "ArrowUp", "↓": "ArrowDown" };
+  return {
+    key: named[key] ?? key,
+    ctrlKey: parts.includes("Ctrl"),
+    metaKey: false,
+    shiftKey: parts.includes("Shift"),
+    altKey: parts.includes("Alt"),
+  };
+}
+
+describe("Help content", () => {
+  it("has no empty or placeholder copy anywhere", () => {
+    expect(allItems.length).toBeGreaterThan(40);
+    for (const { section, subsection, item } of allItems) {
+      const where = `${section.name} / ${subsection.title} / ${item.action}`;
+      expect(section.name.trim(), where).not.toBe("");
+      expect(section.description.trim(), where).not.toBe("");
+      expect(subsection.title.trim(), where).not.toBe("");
+      expect(item.action.trim(), where).not.toBe("");
+      // A one- or two-word description is a placeholder, not an
+      // explanation. The floor is deliberately low: entries in the Keyboard
+      // table are terse on purpose ("Your saved graphs."), and padding them
+      // out to satisfy a word count would make the reference worse.
+      expect(item.description.trim().split(/\s+/).length, where).toBeGreaterThan(2);
+    }
+  });
+
+  it("has unique section names, since the rail addresses sections by name", () => {
+    const names = HELP_SECTIONS.map((s) => s.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  // The whole point of this file. Every chord printed in Help is resolved
+  // through the real dispatcher; an unrecognised chord means the content
+  // promises a key the app does not answer to.
+  it("every key chord it documents is a real, live binding", () => {
+    const chords = allItems.flatMap(({ item }) => item.keys ?? []);
+    expect(chords.length).toBeGreaterThan(10);
+    for (const chord of chords) {
+      expect(resolveShortcut(chordToEvent(chord)), `${chord} resolves to nothing`).not.toBeNull();
+    }
+  });
+
+  it("documents every binding the app actually has", () => {
+    const documented = new Set(
+      allItems.flatMap(({ item }) => (item.keys ?? []).map((c) => resolveShortcut(chordToEvent(c)))),
+    );
+    // Arrow navigation is documented as a pair (Ctrl+left / Ctrl+right)
+    // standing for all four directions, which is how a person reads it -
+    // so the vertical pair is exempt rather than spelled out twice.
+    const expected: ShortcutId[] = [
+      "new-chat", "toggle-library", "save-chat", "create-frame", "create-container",
+      "compare-branches", "synthesize-branches", "toggle-palette", "toggle-search",
+      "toggle-quick-switcher", "navigate-left", "navigate-right", "undo", "redo",
+    ];
+    for (const id of expected) {
+      expect(documented.has(id), `no Help entry documents "${id}"`).toBe(true);
+    }
+  });
+
+  it("names plugins as the picker names them", () => {
+    const copy = JSON.stringify(HELP_SECTIONS);
+    // Renamed in the app and left stale here for at least one release.
+    expect(copy).not.toContain("Graphlink-Web");
+    for (const name of ["Web Research", "Gitlink", "Virtual Environment Runner", "HTML Renderer", "System Prompt", "Conversation Node", "Artifact / Drafter"]) {
+      expect(copy, `${name} is missing from Help`).toContain(name);
+    }
+  });
+
+  it("does not describe controls that were renamed or removed", () => {
+    const copy = JSON.stringify(HELP_SECTIONS);
+    // "Controls" became the View panel; Shift-drag became rubber-band
+    // selection rather than a zoom-to-area gesture.
+    expect(copy).not.toContain("Controls toggle");
+    expect(copy).not.toMatch(/zoom the view to a specific region/i);
+  });
+});
+
+describe("HelpDialog", () => {
+  it("opens on the first section with its rail", () => {
+    renderOpen();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(HELP_SECTIONS[0].name);
+    expect(screen.getByRole("navigation", { name: "Help sections" })).toBeInTheDocument();
+    for (const section of HELP_SECTIONS) {
+      expect(screen.getByRole("button", { name: section.name })).toBeInTheDocument();
+    }
+  });
+
+  it("switches sections from the rail", async () => {
+    const user = userEvent.setup();
+    renderOpen();
+    await user.click(screen.getByRole("button", { name: "Keyboard" }));
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Keyboard");
+  });
+
+  it("renders documented chords as <kbd>, not as prose in the title", () => {
+    renderOpen();
+    // Start Here documents the palette; the chord is an element, so it can
+    // be found as one rather than by parsing a heading string.
+    const kbds = document.querySelectorAll("kbd.help-kbd");
+    expect(kbds.length).toBeGreaterThan(0);
+    expect([...kbds].map((k) => k.textContent)).toContain("Ctrl+K");
+  });
+
+  describe("search", () => {
+    it("finds an entry by a word in its description, across sections", async () => {
+      const user = userEvent.setup();
+      renderOpen();
+      await user.type(screen.getByRole("searchbox", { name: "Search help" }), "minimap");
+      const results = screen.getByRole("region", { name: "Help search results" });
+      expect(within(results).getByText(/Click anywhere in it to jump there/)).toBeInTheDocument();
+    });
+
+    it("finds a shortcut by its chord, which is what people actually type", async () => {
+      const user = userEvent.setup();
+      renderOpen();
+      await user.type(screen.getByRole("searchbox", { name: "Search help" }), "ctrl+p");
+      const results = screen.getByRole("region", { name: "Help search results" });
+      // Two entries name it - the Finding Things explainer and the Keyboard
+      // table row - and both are legitimate hits for the chord.
+      expect(within(results).getAllByText("Quick switcher").length).toBeGreaterThan(0);
+    });
+
+    it("replaces the section view rather than filtering inside it", async () => {
+      const user = userEvent.setup();
+      renderOpen();
+      await user.type(screen.getByRole("searchbox", { name: "Search help" }), "autopilot");
+      // The Builder's section is not selected, but its entry is reachable.
+      expect(screen.queryByRole("region", { name: HELP_SECTIONS[0].name })).toBeNull();
+      const results = screen.getByRole("region", { name: "Help search results" });
+      expect(within(results).getByText(/Co-pilot or Autopilot/)).toBeInTheDocument();
+      // Each result says where it came from, since there are no headings to
+      // sit under in a flat list.
+      expect(within(results).getAllByText(/The Builder · /).length).toBeGreaterThan(0);
+    });
+
+    it("says so plainly when nothing matches", async () => {
+      const user = userEvent.setup();
+      renderOpen();
+      await user.type(screen.getByRole("searchbox", { name: "Search help" }), "zzzznope");
+      expect(screen.getByText('Nothing matches "zzzznope".')).toBeInTheDocument();
+    });
+
+    it("choosing a section clears the query and goes back to browsing", async () => {
+      const user = userEvent.setup();
+      renderOpen();
+      await user.type(screen.getByRole("searchbox", { name: "Search help" }), "budget");
+      await user.click(screen.getByRole("button", { name: "The Agent" }));
+      expect(screen.getByRole("searchbox", { name: "Search help" })).toHaveValue("");
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("The Agent");
+    });
+
+    it("Escape clears the query before it closes the dialog", async () => {
+      const user = userEvent.setup();
+      renderOpen();
+      const box = screen.getByRole("searchbox", { name: "Search help" });
+      await user.type(box, "grid");
+      await user.keyboard("{Escape}");
+      expect(box).toHaveValue("");
+      // Still open: the first Escape was spent on the query.
+      expect(screen.getByRole("navigation", { name: "Help sections" })).toBeInTheDocument();
+    });
+  });
+});

--- a/web_ui/src/app/chrome/HelpDialog.tsx
+++ b/web_ui/src/app/chrome/HelpDialog.tsx
@@ -1,39 +1,142 @@
-import { useState } from "react";
-import { HELP_SECTIONS } from "./help-data/sections";
+import { useMemo, useState } from "react";
+import { HELP_SECTIONS, type HelpItem, type HelpSection } from "./help-data/sections";
 import { Dialog } from "../overlays/overlays";
 
 /**
- * The Help dialog (Qt-removal plan R2.5) - help-web's SPA successor.
+ * The Help panel (Qt-removal plan R2.5) - help-web's SPA successor.
  *
- * Confirmed by recon to be 100% static content (9 sections/19 subsections/
- * 76 items, byte-exact in help-data/sections.ts) with no backend state at
- * all - Python never learned which section was open even in the legacy
- * island. No WS topic, no client store; this is a plain client component
- * whose only "state" (active section) is local UI selection, exactly as
- * before.
+ * Static content, no backend state: Python never learned which section was
+ * open even in the legacy island. No WS topic, no client store.
+ *
+ * SEARCH IS THE MAIN AFFORDANCE, and it was missing. The panel holds ~70
+ * items across ten sections, and the only way in was to guess which section
+ * a thing lived under - which is precisely the guess a person opening Help
+ * has already failed to make. Typing now filters every item in every
+ * section at once, and a query REPLACES the section navigation rather than
+ * narrowing within it: search and browse are two ways to reach the same
+ * content, and letting them run at once (a filtered list inside a chosen
+ * section) means an item you can see in the count but not on screen,
+ * because the wrong section happens to be selected.
+ *
+ * KEY CHORDS ARE DATA, not prose. Shortcut items used to spell their keys
+ * into the title text ("Ctrl + T / Ctrl + L / Ctrl + S" as one heading for
+ * three unrelated commands), which read as one item, could not be searched
+ * for by the command's name, and gave the keys no visual weight at all.
+ * They are a `keys` field now, rendered as <kbd>, so one item means one
+ * command and the chord is the thing your eye lands on.
+ *
+ * The rail's intro paragraph is gone. It said "Graphlink is a visual AI
+ * workspace. Start with the overview, then jump directly to the workflow,
+ * tool, or project area you need" - a sentence of positioning copy and a
+ * sentence instructing the reader to use the list of section buttons
+ * directly beneath it, which the list already affords.
  */
 
-const RAIL_INTRO =
-  "Graphlink is a visual AI workspace. Start with the overview, then jump directly to the workflow, tool, or project area you need.";
+interface Match {
+  section: HelpSection;
+  subsectionTitle: string;
+  item: HelpItem;
+}
+
+/** Substring match over everything a person might type: the item, its
+ *  subsection, its section, and the chords themselves - so "ctrl+f" finds
+ *  canvas search by its key and not only by its name. */
+function matches(query: string): Match[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  const found: Match[] = [];
+  for (const section of HELP_SECTIONS) {
+    for (const subsection of section.subsections) {
+      for (const item of subsection.items) {
+        const haystack = [
+          item.action,
+          item.description,
+          subsection.title,
+          section.name,
+          ...(item.keys ?? []),
+        ]
+          .join(" ")
+          .toLowerCase();
+        if (haystack.includes(q)) found.push({ section, subsectionTitle: subsection.title, item });
+      }
+    }
+  }
+  return found;
+}
+
+function Keys({ keys }: { keys: string[] }) {
+  return (
+    <span className="help-item-keys">
+      {keys.map((chord, index) => (
+        <span key={chord}>
+          {index > 0 && <span className="help-item-keys-or">or</span>}
+          <kbd className="help-kbd">{chord}</kbd>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function Item({ item, context }: { item: HelpItem; context?: string }) {
+  return (
+    <div className="help-item">
+      <p className="help-item-action">
+        <span className="help-item-name">{item.action}</span>
+        {item.keys && <Keys keys={item.keys} />}
+      </p>
+      <p className="help-item-description">{item.description}</p>
+      {context && <p className="help-item-context">{context}</p>}
+    </div>
+  );
+}
 
 export function HelpDialog() {
   const [activeSectionName, setActiveSectionName] = useState(HELP_SECTIONS[0].name);
+  const [query, setQuery] = useState("");
+  const results = useMemo(() => matches(query), [query]);
+  const searching = query.trim().length > 0;
+
   const activeSection =
     HELP_SECTIONS.find((section) => section.name === activeSectionName) ?? HELP_SECTIONS[0];
 
   return (
-    <Dialog name="help" title="Help Center" className="help-dialog">
+    <Dialog name="help" title="Help" className="help-dialog">
       <div className="help-shell">
         <nav className="help-rail" aria-label="Help sections">
-          <p className="help-rail-intro">{RAIL_INTRO}</p>
+          <input
+            type="search"
+            className="help-search"
+            placeholder="Search help"
+            value={query}
+            aria-label="Search help"
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              // Escape clears the query first and closes the dialog only
+              // when there is nothing left to clear. preventDefault is the
+              // overlay system's own "I handled this" signal (overlays.tsx),
+              // so the second Escape still closes normally.
+              if (event.key === "Escape" && query) {
+                event.preventDefault();
+                setQuery("");
+              }
+            }}
+          />
           <div className="help-rail-buttons">
             {HELP_SECTIONS.map((section) => (
               <button
                 key={section.name}
                 type="button"
-                className={"help-rail-button" + (section.name === activeSectionName ? " active" : "")}
-                aria-current={section.name === activeSectionName ? "page" : undefined}
-                onClick={() => setActiveSectionName(section.name)}
+                className={
+                  "help-rail-button" +
+                  (!searching && section.name === activeSectionName ? " active" : "")
+                }
+                aria-current={
+                  !searching && section.name === activeSectionName ? "page" : undefined
+                }
+                onClick={() => {
+                  setQuery("");
+                  setActiveSectionName(section.name);
+                }}
               >
                 {section.name}
               </button>
@@ -41,24 +144,41 @@ export function HelpDialog() {
           </div>
         </nav>
 
-        <div className="help-content" role="region" aria-label={activeSection.name}>
-          <h1 className="help-content-title">{activeSection.name}</h1>
-          <p className="help-content-description">{activeSection.description}</p>
-
-          <div className="help-scroll-area">
-            {activeSection.subsections.map((subsection) => (
-              <section className="help-section-block" key={subsection.title}>
-                <h2 className="help-section-title">{subsection.title}</h2>
-                {subsection.items.map((item, index) => (
-                  <div className="help-item-card" key={`${subsection.title}-${index}`}>
-                    <p className="help-item-action">{item.action}</p>
-                    <p className="help-item-description">{item.description}</p>
-                  </div>
-                ))}
-              </section>
-            ))}
+        {searching ? (
+          <div className="help-content" role="region" aria-label="Help search results">
+            <h1 className="help-content-title">Results</h1>
+            <p className="help-content-description" role="status">
+              {results.length === 0
+                ? `Nothing matches "${query.trim()}".`
+                : `${results.length} ${results.length === 1 ? "entry" : "entries"} for "${query.trim()}".`}
+            </p>
+            <div className="help-scroll-area">
+              {results.map((match, index) => (
+                <Item
+                  key={`${match.section.name}-${match.subsectionTitle}-${index}`}
+                  item={match.item}
+                  context={`${match.section.name} · ${match.subsectionTitle}`}
+                />
+              ))}
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="help-content" role="region" aria-label={activeSection.name}>
+            <h1 className="help-content-title">{activeSection.name}</h1>
+            <p className="help-content-description">{activeSection.description}</p>
+
+            <div className="help-scroll-area">
+              {activeSection.subsections.map((subsection) => (
+                <section className="help-section-block" key={subsection.title}>
+                  <h2 className="help-section-title">{subsection.title}</h2>
+                  {subsection.items.map((item, index) => (
+                    <Item key={`${subsection.title}-${index}`} item={item} />
+                  ))}
+                </section>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </Dialog>
   );

--- a/web_ui/src/app/chrome/ViewPopover.tsx
+++ b/web_ui/src/app/chrome/ViewPopover.tsx
@@ -111,12 +111,91 @@ function useDebouncedSetting<T>(remote: T, commit: (value: T) => void, delayMs =
   return [pending === null ? remote : pending, set] as const;
 }
 
-/** A slider header: what the value is, and what it currently reads. */
+/** A field header: what the setting is, and what it currently reads. */
 function FieldRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="view-field-row">
       <span className="view-field-label">{label}</span>
       <span className="view-field-value">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * A numeric setting: name, live value, one slider, and - where the backend
+ * publishes them - its landmark values as scale marks under the track.
+ *
+ * ONE CONTROL PER VALUE, which is the main thing this popover was missing.
+ * Pan speed and grid spacing each used to render a value badge, a slider,
+ * AND a four-button segmented control, all bound to the same number and
+ * stacked vertically: three representations of one setting, with nothing
+ * saying which was authoritative. That is a straight artifact of the port -
+ * the Qt controls offered presets, the SPA rewrite added sliders, and
+ * neither was taken away.
+ *
+ * The presets are worth keeping (they are the values the backend actually
+ * publishes as landmarks), so they stay - as small marks belonging to the
+ * slider's scale rather than as a competing control. Half the height, and
+ * no ambiguity about what sets the value.
+ *
+ * The track's fill is driven by --view-slider-fill rather than by a second
+ * element: a custom property set on the input inherits into the
+ * ::-webkit-slider-runnable-track pseudo-element, which is the only way to
+ * paint progress on a range input in this engine.
+ */
+function SliderField({
+  label,
+  ariaLabel,
+  value,
+  display,
+  min,
+  max,
+  presets,
+  formatPreset,
+  onInput,
+  onPreset,
+}: {
+  label: string;
+  ariaLabel: string;
+  value: number;
+  display: string;
+  min: number;
+  max: number;
+  presets?: readonly number[];
+  formatPreset?: (value: number) => string;
+  onInput: (value: number) => void;
+  onPreset?: (value: number) => void;
+}) {
+  const span = max - min;
+  const fill = span > 0 ? ((value - min) / span) * 100 : 0;
+  return (
+    <div className="view-field">
+      <FieldRow label={label} value={display} />
+      <input
+        type="range"
+        className="view-slider"
+        style={{ ["--view-slider-fill" as string]: `${Math.min(100, Math.max(0, fill))}%` }}
+        min={min}
+        max={max}
+        value={value}
+        aria-label={ariaLabel}
+        onChange={(e) => onInput(Number(e.target.value))}
+      />
+      {presets && presets.length > 0 && onPreset && (
+        <div className="view-ticks" role="group" aria-label={`${ariaLabel} presets`}>
+          {presets.map((preset) => (
+            <button
+              key={preset}
+              type="button"
+              className={"view-tick" + (preset === value ? " active" : "")}
+              aria-pressed={preset === value}
+              onClick={() => onPreset(preset)}
+            >
+              {formatPreset ? formatPreset(preset) : preset}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -201,15 +280,41 @@ function SwatchRow({
  * their presets (published by the backend), their intent names - instead of
  * three separately-positioned popover cards.
  *
- * Redesigned past the literal port: every slider carries a label and a live
- * value readout; grid style is a segmented control; the font family uses
- * the app's own CustomSelect (the component built precisely because bare
- * <select> was ruled off-idiom) with a live preview of the resulting node
- * typography; connection toggles live in their own CONNECTIONS section
- * rather than under GRID (an artifact of which Qt bridge happened to own
- * them); color rows gained a free-choice picker; the filter section grew
- * group labels and a clear affordance; and a footer resets everything to
- * the documented defaults.
+ * WHAT THIS PASS FIXED, and why it was there. The first version of this
+ * panel was a consolidation of three Qt islands, and it consolidated them
+ * additively: whatever each island had, plus whatever the SPA rewrite
+ * introduced, stacked in the order it was written. The result read as a
+ * port rather than as a panel.
+ *
+ * - DUPLICATE CONTROLS. Pan speed and grid spacing each rendered a value
+ *   badge, a slider, and a four-button segmented control - three
+ *   representations of one number, stacked. Grid style rendered its value
+ *   as a badge directly above a segmented control already showing it. Each
+ *   setting has one control now; the published landmark values live on the
+ *   slider's own scale (see SliderField).
+ * - READOUTS DRESSED AS BUTTONS. Every value badge was a bordered,
+ *   inset-filled pill - the exact shape of .view-chip, which IS a button.
+ *   They are plain tabular text now, aligned right, and nothing that cannot
+ *   be clicked looks like it can.
+ * - OS CHECKBOXES. The toggles were the one place in this panel wearing
+ *   engine chrome, next to a fully custom slider, segmented control and
+ *   swatch row.
+ * - A TRACK THAT SHOWED NOTHING. The slider's track was a single flat bar,
+ *   so the only cue for a value was thumb position; the track is filled to
+ *   the value now, which is what makes a row of sliders readable at a
+ *   glance.
+ * - SECTIONS BY BRIDGE, NOT BY MEANING. "Snap to Grid" and "Smart Guides"
+ *   are drag behaviours and sat under GRID (appearance) because the legacy
+ *   grid bridge happened to own their checkboxes - the same accident that
+ *   had already put the connection toggles there. They are in CANVAS now,
+ *   with the pan speed, which is where the rest of "how moving around
+ *   behaves" lives. "Focus Accepted Paths" was a one-toggle BRANCHES
+ *   section sitting immediately above FILTER while doing the same job as
+ *   it - dimming what you are not looking at - so it opens that section
+ *   instead of preceding it.
+ * - A FOOTER THAT SCROLLED AWAY. Reset to Defaults was the last thing in a
+ *   panel taller than the popover, so getting to it meant scrolling past
+ *   every control it undoes. It is pinned to the bottom.
  */
 export function ViewPopover({ store }: { store: SceneStore }) {
   const scene = useSyncExternalStore(store.subscribe, store.getScene);
@@ -266,223 +371,215 @@ export function ViewPopover({ store }: { store: SceneStore }) {
 
   return (
     <Popover name="view" label="View settings" className="view-popover" anchored>
-      <section className="view-section" aria-label="Canvas pan speed">
-        <p className="view-section-title">Navigation</p>
-        <FieldRow label="Canvas pan speed" value={`${dragPercent}%`} />
-        <input
-          type="range"
-          className="view-slider"
-          min={dragConfig.percentMin}
-          max={dragConfig.percentMax}
-          value={dragPercent}
-          aria-label="Canvas pan speed"
-          onChange={(e) => setDragPercent(Number(e.target.value))}
-        />
-        <div className="view-segment" role="group" aria-label="Drag speed presets">
-          {dragConfig.percentPresets.map((percent) => (
-            <button
-              key={percent}
-              type="button"
-              className={"view-segment-btn" + (percent === dragPercent ? " active" : "")}
-              aria-pressed={percent === dragPercent}
-              onClick={() => store.setDragFactor(percent / 100)}
-            >
-              {percent}%
-            </button>
-          ))}
-        </div>
-      </section>
+      <div className="view-scroll">
+        <section className="view-section" aria-label="Canvas">
+          <p className="view-section-title">Canvas</p>
+          <SliderField
+            label="Pan speed"
+            ariaLabel="Canvas pan speed"
+            value={dragPercent}
+            display={`${dragPercent}%`}
+            min={dragConfig.percentMin}
+            max={dragConfig.percentMax}
+            presets={dragConfig.percentPresets}
+            formatPreset={(p) => `${p}%`}
+            onInput={setDragPercent}
+            onPreset={(p) => store.setDragFactor(p / 100)}
+          />
+          <ToggleRow
+            label="Snap to Grid"
+            hint="Dragged nodes land on grid lines"
+            checked={scene.snapToGrid}
+            onChange={(v) => store.setSnapToGrid(v)}
+          />
+          <ToggleRow
+            label="Smart Guides"
+            hint="Snap to alignments with nearby nodes"
+            checked={scene.smartGuides}
+            onChange={(v) => store.setSmartGuides(v)}
+          />
+        </section>
 
-      <section className="view-section" aria-label="Grid">
-        <p className="view-section-title">Grid</p>
-        <FieldRow label="Spacing" value={`${gridSize}px`} />
-        <input
-          type="range"
-          className="view-slider"
-          min={GRID_SIZE_MIN}
-          max={GRID_SIZE_MAX}
-          value={gridSize}
-          aria-label="Grid spacing"
-          onChange={(e) => setGridSize(Number(e.target.value))}
-        />
-        <div className="view-segment" role="group" aria-label="Grid spacing presets">
-          {grid.sizePresets.map((size) => (
-            <button
-              key={size}
-              type="button"
-              className={"view-segment-btn" + (size === gridSize ? " active" : "")}
-              aria-pressed={size === gridSize}
-              onClick={() => store.setGridSize(size)}
-            >
-              {size}px
-            </button>
-          ))}
-        </div>
-        <FieldRow label="Opacity" value={`${gridOpacity}%`} />
-        <input
-          type="range"
-          className="view-slider"
-          min={0}
-          max={100}
-          value={gridOpacity}
-          aria-label="Grid opacity"
-          onChange={(e) => setGridOpacity(Number(e.target.value))}
-        />
-        <FieldRow label="Style" value={grid.gridStyle} />
-        <div className="view-segment" role="group" aria-label="Grid style">
-          {grid.stylePresets.map((style) => (
-            <button
-              key={style}
-              type="button"
-              className={"view-segment-btn" + (style === grid.gridStyle ? " active" : "")}
-              aria-pressed={style === grid.gridStyle}
-              onClick={() => store.setGridStyle(style)}
-            >
-              {style}
-            </button>
-          ))}
-        </div>
-        <FieldRow label="Color" value={gridColor.toUpperCase()} />
-        <SwatchRow
-          presets={grid.colorPresets}
-          current={gridColor}
-          ariaPrefix="Grid color"
-          onPick={setGridColor}
-        />
-        <ToggleRow
-          label="Snap to Grid"
-          hint="Dragged nodes land on grid lines"
-          checked={scene.snapToGrid}
-          onChange={(v) => store.setSnapToGrid(v)}
-        />
-        <ToggleRow
-          label="Smart Guides"
-          hint="Snap to alignments with nearby nodes"
-          checked={scene.smartGuides}
-          onChange={(v) => store.setSmartGuides(v)}
-        />
-      </section>
+        <section className="view-section" aria-label="Grid">
+          <p className="view-section-title">Grid</p>
+          <SliderField
+            label="Spacing"
+            ariaLabel="Grid spacing"
+            value={gridSize}
+            display={`${gridSize}px`}
+            min={GRID_SIZE_MIN}
+            max={GRID_SIZE_MAX}
+            presets={grid.sizePresets}
+            formatPreset={(s) => `${s}px`}
+            onInput={setGridSize}
+            onPreset={(s) => store.setGridSize(s)}
+          />
+          <SliderField
+            label="Opacity"
+            ariaLabel="Grid opacity"
+            value={gridOpacity}
+            display={`${gridOpacity}%`}
+            min={0}
+            max={100}
+            onInput={setGridOpacity}
+          />
+          {/* No value readout above this one: the segmented control IS the
+              readout - the selected segment says "Dots" as plainly as a
+              badge above it did. */}
+          <div className="view-field">
+            <span className="view-field-label">Style</span>
+            <div className="view-segment" role="group" aria-label="Grid style">
+              {grid.stylePresets.map((style) => (
+                <button
+                  key={style}
+                  type="button"
+                  className={"view-segment-btn" + (style === grid.gridStyle ? " active" : "")}
+                  aria-pressed={style === grid.gridStyle}
+                  onClick={() => store.setGridStyle(style)}
+                >
+                  {style}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="view-field">
+            <FieldRow label="Color" value={gridColor.toUpperCase()} />
+            <SwatchRow
+              presets={grid.colorPresets}
+              current={gridColor}
+              ariaPrefix="Grid color"
+              onPick={setGridColor}
+            />
+          </div>
+        </section>
 
-      {/* Fade/orthogonal lived under GRID in the straight port only because
-          the legacy grid-control bridge happened to own their checkboxes;
-          they configure connections, so they get a section that says so. */}
-      <section className="view-section" aria-label="Connections">
-        <p className="view-section-title">Connections</p>
-        <ToggleRow
-          label="Fade Connections"
-          hint="Dim all lines except the one under the pointer"
-          checked={scene.fadeConnectionsEnabled}
-          onChange={(v) => store.setFadeConnections(v)}
-        />
-        <ToggleRow
-          label="Orthogonal Routing"
-          hint="Route eligible lines at right angles"
-          checked={scene.orthogonalRouting}
-          onChange={(v) => store.setOrthogonalConnections(v)}
-        />
-      </section>
+        {/* Fade/orthogonal lived under GRID in the straight port only because
+            the legacy grid-control bridge happened to own their checkboxes;
+            they configure connections, so they get a section that says so. */}
+        <section className="view-section" aria-label="Connections">
+          <p className="view-section-title">Connections</p>
+          <ToggleRow
+            label="Fade Connections"
+            hint="Dim all lines except the one under the pointer"
+            checked={scene.fadeConnectionsEnabled}
+            onChange={(v) => store.setFadeConnections(v)}
+          />
+          <ToggleRow
+            label="Orthogonal Routing"
+            hint="Route eligible lines at right angles"
+            checked={scene.orthogonalRouting}
+            onChange={(v) => store.setOrthogonalConnections(v)}
+          />
+        </section>
 
-      <section className="view-section" aria-label="Font">
-        <p className="view-section-title">Node Font</p>
-        <CustomSelect
-          value={scene.fontFamily}
-          options={fontConfig.fontFamilies.map((family) => ({ id: family, label: family }))}
-          onChange={(family) => store.setFontFamily(family)}
-          ariaLabel="Font family"
-        />
-        <FieldRow label="Size" value={`${fontSizePt}pt`} />
-        <input
-          type="range"
-          className="view-slider"
-          min={fontConfig.sizeMin}
-          max={fontConfig.sizeMax}
-          value={fontSizePt}
-          aria-label="Font size"
-          onChange={(e) => setFontSizePt(Number(e.target.value))}
-        />
-        <FieldRow label="Color" value={fontColor.toUpperCase()} />
-        <SwatchRow
-          presets={fontConfig.colorPresets}
-          current={fontColor}
-          ariaPrefix="Font color"
-          onPick={setFontColor}
-        />
-        {/* What the settings above actually produce on a node card - the
-            readout the three separate controls never had. */}
-        <div
-          className="view-font-preview"
-          aria-hidden="true"
-          style={{
-            fontFamily: scene.fontFamily,
-            fontSize: `${fontSizePt}pt`,
-            color: fontColor,
-          }}
-        >
-          The quick brown fox jumps over the lazy dog
-        </div>
-      </section>
+        <section className="view-section" aria-label="Node font">
+          <p className="view-section-title">Node Font</p>
+          <div className="view-field">
+            <span className="view-field-label">Family</span>
+            <CustomSelect
+              value={scene.fontFamily}
+              options={fontConfig.fontFamilies.map((family) => ({ id: family, label: family }))}
+              onChange={(family) => store.setFontFamily(family)}
+              ariaLabel="Font family"
+            />
+          </div>
+          <SliderField
+            label="Size"
+            ariaLabel="Font size"
+            value={fontSizePt}
+            display={`${fontSizePt}pt`}
+            min={fontConfig.sizeMin}
+            max={fontConfig.sizeMax}
+            onInput={setFontSizePt}
+          />
+          <div className="view-field">
+            <FieldRow label="Color" value={fontColor.toUpperCase()} />
+            <SwatchRow
+              presets={fontConfig.colorPresets}
+              current={fontColor}
+              ariaPrefix="Font color"
+              onPick={setFontColor}
+            />
+          </div>
+          {/* What the settings above actually produce on a node card - the
+              readout the three separate controls never had. */}
+          <div
+            className="view-font-preview"
+            aria-hidden="true"
+            style={{
+              fontFamily: scene.fontFamily,
+              fontSize: `${fontSizePt}pt`,
+              color: fontColor,
+            }}
+          >
+            The quick brown fox jumps over the lazy dog
+          </div>
+        </section>
 
-      <section className="view-section" aria-label="Branches">
-        <p className="view-section-title">Branches</p>
-        {/* ADR-002 Workstream 1 ("Branch status and lifecycle"): dims every
-            node outside the accepted paths (rejected/superseded branches
-            and their descendants, unless an explicit "accepted" override
-            reactivates a sub-branch) - the whole-graph counterpart to a
-            single chat node's own "Hide Other Branches" menu action.
-            Backed by sceneStore's own local focusAcceptedPaths field
-            rather than `scene` - see that field's own comment. */}
-        <ToggleRow
-          label="Focus Accepted Paths"
-          hint="Dim rejected and superseded branches"
-          checked={focusAcceptedPaths}
-          onChange={(v) => store.setFocusAcceptedPaths(v)}
-        />
-      </section>
+        <section className="view-section" aria-label="Focus">
+          <div className="view-section-head">
+            <p className="view-section-title">Focus</p>
+            {filterCount > 0 && (
+              <button type="button" className="view-clear-btn" onClick={() => store.clearFilters()}>
+                Clear ({filterCount})
+              </button>
+            )}
+          </div>
+          {/* ADR-002 Workstream 1 ("Branch status and lifecycle"): dims every
+              node outside the accepted paths (rejected/superseded branches
+              and their descendants, unless an explicit "accepted" override
+              reactivates a sub-branch) - the whole-graph counterpart to a
+              single chat node's own "Hide Other Branches" menu action.
+              Backed by sceneStore's own local focusAcceptedPaths field
+              rather than `scene` - see that field's own comment. It opens
+              this section rather than owning a one-toggle section of its
+              own directly above it: dimming rejected branches and dimming
+              filtered-out kinds are the same job. */}
+          <ToggleRow
+            label="Focus Accepted Paths"
+            hint="Dim rejected and superseded branches"
+            checked={focusAcceptedPaths}
+            onChange={(v) => store.setFocusAcceptedPaths(v)}
+          />
+          {/* ADR-012 stage 12.5: multi-select toggle chips - "active" means
+              "toggled into the filter set," not mutual exclusion; a click
+              only ever flips ITS OWN membership in sceneStore's filterKinds/
+              filterStatuses Sets. An empty set (no chip active) means no
+              filter at all - every node shows at full opacity. */}
+          <p className="view-subsection-title">By kind</p>
+          <div className="view-row" role="group" aria-label="Filter by node kind">
+            {FILTERABLE_NODE_KINDS.map((kind) => (
+              <button
+                key={kind}
+                type="button"
+                className={"view-chip" + (filterKinds.has(kind) ? " active" : "")}
+                aria-pressed={filterKinds.has(kind)}
+                onClick={() => store.toggleFilterKind(kind)}
+              >
+                {FILTER_KIND_LABELS[kind]}
+              </button>
+            ))}
+          </div>
+          <p className="view-subsection-title">By branch status</p>
+          <div className="view-row" role="group" aria-label="Filter by branch status">
+            {FILTER_STATUS_VALUES.map((status) => (
+              <button
+                key={status}
+                type="button"
+                className={"view-chip" + (filterStatuses.has(status) ? " active" : "")}
+                aria-pressed={filterStatuses.has(status)}
+                onClick={() => store.toggleFilterStatus(status)}
+              >
+                {FILTER_STATUS_LABELS[status]}
+              </button>
+            ))}
+          </div>
+        </section>
+      </div>
 
-      <section className="view-section" aria-label="Filter">
-        <div className="view-section-head">
-          <p className="view-section-title">Filter</p>
-          {filterCount > 0 && (
-            <button type="button" className="view-clear-btn" onClick={() => store.clearFilters()}>
-              Clear ({filterCount})
-            </button>
-          )}
-        </div>
-        {/* ADR-012 stage 12.5: multi-select toggle chips - "active" means
-            "toggled into the filter set," not mutual exclusion; a click
-            only ever flips ITS OWN membership in sceneStore's filterKinds/
-            filterStatuses Sets. An empty set (no chip active) means no
-            filter at all - every node shows at full opacity. */}
-        <p className="view-subsection-title">By kind</p>
-        <div className="view-row" role="group" aria-label="Filter by node kind">
-          {FILTERABLE_NODE_KINDS.map((kind) => (
-            <button
-              key={kind}
-              type="button"
-              className={"view-chip" + (filterKinds.has(kind) ? " active" : "")}
-              aria-pressed={filterKinds.has(kind)}
-              onClick={() => store.toggleFilterKind(kind)}
-            >
-              {FILTER_KIND_LABELS[kind]}
-            </button>
-          ))}
-        </div>
-        <p className="view-subsection-title">By branch status</p>
-        <div className="view-row" role="group" aria-label="Filter by branch status">
-          {FILTER_STATUS_VALUES.map((status) => (
-            <button
-              key={status}
-              type="button"
-              className={"view-chip" + (filterStatuses.has(status) ? " active" : "")}
-              aria-pressed={filterStatuses.has(status)}
-              onClick={() => store.toggleFilterStatus(status)}
-            >
-              {FILTER_STATUS_LABELS[status]}
-            </button>
-          ))}
-        </div>
-      </section>
-
+      {/* Outside .view-scroll on purpose: the panel is taller than the
+          popover, and a footer inside the scroller means scrolling past
+          every control this button undoes in order to reach it. */}
       <div className="view-footer">
         <button type="button" className="view-reset-btn" onClick={resetAll}>
           Reset to Defaults

--- a/web_ui/src/app/chrome/help-data/sections.ts
+++ b/web_ui/src/app/chrome/help-data/sections.ts
@@ -1,15 +1,44 @@
-/* GENERATED - do not hand-edit. Source of truth was the legacy
- * HelpDialog.SECTION_DEFS in graphlink_ui_dialogs/graphlink_system_dialogs.py
- * (deleted in Phase 4's shim-collapse increment once this file existed) -
- * mechanically extracted (icon fields dropped per the Phase 4 scope note;
- * see doc/FRONTEND_WEB_MIGRATION_MASTER_PLAN.md), not hand-retyped, so the
- * 76 items/19 subsections/9 sections of copy carried over byte-exact.
- * This is now the single canonical source - nothing else reads this
- * content, per "adding a section requires no Python change." */
+/**
+ * The Help panel's content.
+ *
+ * HAND-MAINTAINED. This file used to open with "GENERATED - do not
+ * hand-edit", inherited from the Qt-era extraction that first produced it
+ * (the legacy HelpDialog.SECTION_DEFS in graphlink_system_dialogs.py, long
+ * since deleted). That header stopped being true the first time someone
+ * added a section by hand, and by the time it was audited the file had
+ * grown from the 76 items it claimed to 88 - so the one instruction at the
+ * top of the file was both false and discouraging the exact maintenance the
+ * file was getting anyway. Edit it. Nothing generates it.
+ *
+ * WHAT THIS IS FOR. Someone opens Help because something on screen did not
+ * do what they expected, or because they suspect the app can do a thing and
+ * want to know where it lives. Both are answered by specifics: the real
+ * label on the real control, the actual key, the actual limit. Neither is
+ * answered by a paragraph about how the workspace empowers their workflow.
+ *
+ * SO: say the thing. Lead with the fact, not with a restatement of the
+ * item's own title. Give the shortcut if there is one. Say where a feature
+ * stops - what it will not do, what it cannot undo, what it costs - because
+ * that is the part nobody can discover by clicking around, and it is the
+ * part that makes the rest trustworthy. One sentence is a fine length. So
+ * is four, when four are needed. What kills a reference page is every entry
+ * being the same shape.
+ *
+ * KEEP IT TRUE. Every label here is quoted from the running app. When a
+ * control is renamed, this file is part of the change, not a follow-up.
+ * The audit that produced this rewrite found the Help panel confidently
+ * describing a "Controls toggle" renamed to View, a Shift-drag zoom gesture
+ * that had become rubber-band selection, and a "Graphlink-Web" plugin
+ * shipping under the name Web Research - three things a reader would have
+ * trusted and then failed to find.
+ */
 
 export interface HelpItem {
   action: string;
   description: string;
+  /** Key chords for this item, each rendered as its own <kbd>. Two entries
+   *  mean "either one works", which is a real case here (redo). */
+  keys?: string[];
 }
 
 export interface HelpSubsection {
@@ -25,536 +54,700 @@ export interface HelpSection {
 
 export const HELP_SECTIONS: HelpSection[] = [
   {
-    "name": "Overview",
-    "description": "What Graphlink is, how work is structured, and how a typical project moves from prompt to polished output.",
-    "subsections": [
+    name: "Start Here",
+    description: "What this app is, and the loop everything else hangs off.",
+    subsections: [
       {
-        "title": "What Graphlink Does",
-        "items": [
+        title: "The Idea",
+        items: [
           {
-            "action": "Visual AI Workspace",
-            "description": "Graphlink turns prompts, replies, notes, charts, documents, code, and plugin runs into connected items on one canvas. Instead of losing work inside a single scrolling transcript, you can keep multiple lines of thought visible at once."
+            action: "A graph, not a transcript",
+            description:
+              "Every prompt, reply, note, chart and tool run is a node on a canvas, connected to whatever it came from. A chat window forces one line of thought and buries the rest above the scroll. Here the alternatives stay side by side, and the connections record which answer came from which question.",
           },
           {
-            "action": "Branch-Based Conversations",
-            "description": "Every selected node becomes the anchor for what you do next. That makes it easy to fork alternatives, compare directions, and keep complex work organized as a family of branches instead of one long thread."
+            action: "The selected node is the context",
+            description:
+              "Whatever you have selected is the parent of whatever you do next. Select a reply and send a message, and the new node hangs off that reply with its history. Select a different one and you have branched. This is the single rule the rest of the app is built on - the composer's placeholder tells you which node it is about to answer.",
           },
           {
-            "action": "Mixed Content Graph",
-            "description": "A single project can contain chat nodes, code blocks, visible reasoning, attached files, generated images, notes, charts, and specialist tool nodes. The connections preserve where an idea came from and what it produced."
+            action: "It is a project file, not a session",
+            description:
+              "Nodes, frames, containers, pins, notes and plugin state persist, and a graph reopens from the Library exactly as you left it. Work that spans a week belongs here more than work that spans five minutes.",
           },
-          {
-            "action": "Saved Project Space",
-            "description": "Chats, plugin state, frames, containers, pins, and notes are persisted and can be reopened from the Library. Graphlink is designed for ongoing project work, not just one-off prompts."
-          }
-        ]
+        ],
       },
       {
-        "title": "Typical Session Flow",
-        "items": [
+        title: "Your First Ten Minutes",
+        items: [
           {
-            "action": "Start or Resume",
-            "description": "Open a recent project from the Library, or press Ctrl+T to start a new chat. The app is comfortable for quick ideation and for returning to long-running work."
+            action: "Make a node",
+            description:
+              "Double-click empty canvas. Or just type in the composer at the bottom and send.",
           },
           {
-            "action": "Build a Branch",
-            "description": "Send a prompt, review the result, then select the exact node you want to continue from. Each selection creates a deliberate branch point so you can refine or challenge a result without overwriting earlier work."
+            action: "Branch off an answer",
+            description:
+              "Click the reply you liked, then send your follow-up. Click a different reply and send a different follow-up. You now have two branches from the same point, and neither overwrote the other.",
           },
           {
-            "action": "Add Specialist Nodes",
-            "description": "When a branch needs something more than a plain reply, open Plugins to add reasoning, web research, coding, sandbox execution, drafting, HTML rendering, or branch comparison tools."
+            action: "Reach for a specialist",
+            description:
+              "Plugins in the toolbar adds a node that does something a plain reply cannot - research the web with citations, run Python, render HTML, draft a document. It attaches to the node you have selected.",
           },
           {
-            "action": "Capture the Outcome",
-            "description": "Use notes, explainers, takeaways, charts, exports, and document views to turn raw responses into a clearer project record. The goal is a canvas you can revisit and understand later."
-          }
-        ]
-      }
-    ]
+            action: "When you lose the thread",
+            description:
+              "Fit All frames everything on the canvas. The command palette finds any action by name. Both are faster than hunting.",
+            keys: ["Ctrl+K"],
+          },
+        ],
+      },
+      {
+        title: "Three Ways People Use It",
+        items: [
+          {
+            action: "Compare instead of decide early",
+            description:
+              "Ask the same question three ways from the same parent, leave all three on the canvas, and choose once you can see them together. Compare Branches puts two side by side; Synthesize Branches merges what survived.",
+            keys: ["Ctrl+Shift+C", "Ctrl+Shift+M"],
+          },
+          {
+            action: "Debug with the code that actually ran",
+            description:
+              "Keep the failing code in a Virtual Environment Runner node, the reasoning in its own branch, and the fix attempts as siblings. The run output stays attached to the attempt that produced it, which is the thing a chat log loses first.",
+          },
+          {
+            action: "Write long, in pieces",
+            description:
+              "An Artifact / Drafter node holds a living document while the branches around it argue about sections. The draft is one node you keep editing, not thirty replies you have to reassemble.",
+          },
+        ],
+      },
+    ],
   },
   {
-    "name": "Canvas & Branching",
-    "description": "How selection, context inheritance, branching, and side-by-side exploration work inside the graph.",
-    "subsections": [
+    name: "The Canvas",
+    description: "Moving around, selecting, branching, and what the gestures actually do.",
+    subsections: [
       {
-        "title": "How Branches Work",
-        "items": [
+        title: "Moving Around",
+        items: [
           {
-            "action": "Active Context Node",
-            "description": "The node you select becomes the parent for your next message or specialist tool. The input placeholder updates to show what you are responding to, which helps you stay oriented in large graphs."
+            action: "Pan",
+            description:
+              "Drag empty canvas with the left or middle button. Pan speed is adjustable - View, then Canvas, then Pan speed - which matters more than it sounds once a graph is bigger than a screen.",
           },
           {
-            "action": "Parent and Child History",
-            "description": "Branches inherit the relevant conversation history from their anchor node. Sibling branches can explore different ideas from the same point without stomping on each other."
+            action: "Zoom",
+            description:
+              "The mouse wheel zooms. Holding Ctrl while you scroll does the same thing, so either habit works. The toolbar's zoom readout shows the current level; click it to go back to 100%.",
           },
           {
-            "action": "Focus One Branch",
-            "description": "Chat nodes can temporarily hide other branches so you can concentrate on one path. This is especially useful once a graph starts to fan out into several competing directions."
+            action: "Fit All",
+            description:
+              "Reframes the view around everything on the canvas. The one control worth learning first, because it is the way back from anywhere.",
           },
           {
-            "action": "Regenerate from the Same Context",
-            "description": "Assistant responses can be regenerated from their parent branch when you want a fresh answer without manually rebuilding the surrounding context."
-          }
-        ]
+            action: "Minimap",
+            description:
+              "Bottom right. Click anywhere in it to jump there. It earns its keep at about the point the graph stops fitting on one screen.",
+          },
+        ],
       },
       {
-        "title": "Working on the Canvas",
-        "items": [
+        title: "Selecting",
+        items: [
           {
-            "action": "Select and Move",
-            "description": "Click a node to select it, drag on empty space to rubber-band select, and move one item or a whole group together. The graph behaves like a visual workspace, not a locked transcript."
+            action: "Click to select",
+            description: "One node. This also sets the context for your next message.",
           },
           {
-            "action": "Collapse Dense Areas",
-            "description": "Most major node types can collapse to keep the canvas readable. Collapse is especially helpful when a branch is stable but still needs to stay connected to the rest of the project."
+            action: "Shift-drag to rubber-band",
+            description:
+              "Hold Shift and drag across empty canvas to select everything inside the rectangle. Shift is what distinguishes this from panning - without it, dragging the background moves the view.",
           },
           {
-            "action": "Keep Notes Beside the Work",
-            "description": "Notes live alongside AI nodes rather than inside them. Use them for decisions, TODOs, pasted snippets, executive summaries, or anything that should stay visible but should not be sent back to the model."
+            action: "Ctrl-arrow to walk the branch",
+            description:
+              "Moves the selection to the parent, child or sibling of the current node. Reviewing a branch this way is considerably faster than aiming at each card.",
+            keys: ["Ctrl+←", "Ctrl+→"],
           },
           {
-            "action": "Compare Alternatives",
-            "description": "Select two or more branch tips and run Compare Branches (Ctrl+Shift+C, or the command palette) to get a note explaining where their logic, direction, and intent diverge. Synthesize Branches (Ctrl+Shift+M) instead merges them into one reply, using instructions you type next in the composer."
-          }
-        ]
-      }
-    ]
+            action: "Delete removes the selection",
+            description:
+              "Whatever is selected, however many. Undo brings it back - the undo stack lives on the backend and survives more than you would expect.",
+            keys: ["Ctrl+Z"],
+          },
+        ],
+      },
+      {
+        title: "Branching",
+        items: [
+          {
+            action: "History is inherited, not shared",
+            description:
+              "A branch carries the conversation down its own path from its anchor node. Two siblings from the same parent see the same history behind them and nothing of each other, which is what makes them a fair comparison.",
+          },
+          {
+            action: "Regenerate",
+            description:
+              "Re-asks from the same parent with the same context. Use it when the answer was wrong rather than the question.",
+          },
+          {
+            action: "Hide other branches",
+            description:
+              "A chat node's own menu can dim everything outside its path, for when the canvas has fanned out further than you can hold in your head. View, then Focus, then Focus Accepted Paths does the same thing graph-wide using branch status.",
+          },
+          {
+            action: "Mark what survived",
+            description:
+              "Branches can be set Accepted, Rejected or Superseded. Nothing is deleted - the rejected attempt stays on the canvas as a record of what you tried - but the filters and the focus lens can then dim it out of the way.",
+          },
+        ],
+      },
+    ],
   },
   {
-    "name": "Nodes & Content",
-    "description": "The main node types you will see on the canvas and what each one is best at.",
-    "subsections": [
+    name: "Node Types",
+    description: "What each kind of node is for, and when to reach for it.",
+    subsections: [
       {
-        "title": "Core Conversation Nodes",
-        "items": [
+        title: "Conversation",
+        items: [
           {
-            "action": "Chat Nodes",
-            "description": "User and assistant chat nodes are the backbone of the application. Selecting one lets you continue exactly that line of thought, which makes branching feel intentional instead of accidental."
+            action: "Chat",
+            description: "A prompt and its reply. The default, and most of any graph.",
           },
           {
-            "action": "Code Nodes",
-            "description": "When a response includes fenced code, Graphlink breaks it into dedicated code nodes. Those nodes can be copied, exported, regenerated through their parent reply, or used as a starting point for coding tools."
+            action: "Conversation",
+            description:
+              "A self-contained linear thread in one node, for the stretches where branching is not the point and you just want a normal back-and-forth.",
           },
           {
-            "action": "Thinking Nodes",
-            "description": "If a model returns visible reasoning or analysis, the app stores it as a separate thinking node. This keeps long reasoning trails available without burying the main answer."
+            action: "Thinking",
+            description:
+              "The model's reasoning, kept separate from its answer so you can read the working without it crowding the result. Produced when the Reasoning level in the composer is above Off.",
           },
           {
-            "action": "Document and Image Nodes",
-            "description": "Attachments become their own nodes on the branch so the source material remains visible next to the prompt that used it. That makes it easier to audit what the model actually saw."
-          }
-        ]
+            action: "Code",
+            description:
+              "A code block split out of a reply, so it can be copied, run or edited without dragging the prose along with it.",
+          },
+        ],
       },
       {
-        "title": "Supporting Content",
-        "items": [
+        title: "Content",
+        items: [
           {
-            "action": "Notes",
-            "description": "Manual notes, takeaways, explainer notes, and multi-node summary notes all live as movable note items. They are ideal for turning raw model output into cleaner project knowledge."
+            action: "Note",
+            description:
+              "Your own text, attached wherever you put it. The command palette makes one; there is deliberately no shortcut, because a note you meant to make is worth two seconds.",
           },
           {
-            "action": "Charts",
-            "description": "The app can turn text-derived or numeric content into bar, line, pie, histogram, and Sankey charts on the canvas. Charts are useful when a branch contains data you want to explain visually."
+            action: "Document and Image",
+            description:
+              "Attached files become nodes. Documents open in a reading pane with a table of contents and in-document search; images open at full size.",
           },
           {
-            "action": "Document View",
-            "description": "Long chat content can be opened in the document viewer for easier reading and review. This is especially helpful for lengthy drafts, specifications, or dense research summaries."
+            action: "Chart",
+            description:
+              "Generated from data in the conversation and rendered live, not as a picture of a chart. The underlying data stays inspectable.",
           },
           {
-            "action": "HTML Preview",
-            "description": "The HTML Renderer node can take markup and show a live preview inside the graph, with an optional pop-out preview window for closer inspection."
+            action: "Artifact",
+            description:
+              "A living Markdown document with a source and preview split. Meant to be revised in place across many turns.",
+          },
+        ],
+      },
+      {
+        title: "Agents and Tools",
+        items: [
+          {
+            action: "Plan",
+            description:
+              "The Builder's checklist. It shows the steps, which one is running, what has been spent against the budgets, and every tool call the run has made.",
           },
           {
-            "action": "Node Context Menus",
-            "description": "Right-click chat, code, and plugin nodes for copy, export, document view, branch isolation, regeneration, takeaways, explainers, charts, image generation, and deletion actions. When multiple chat nodes are selected, the menu also exposes group summary workflows."
-          }
-        ]
-      }
-    ]
+            action: "Agent",
+            description:
+              "The workspace agent's card - its task, the folder it is bound to, its turns, and any approval it is currently waiting on.",
+          },
+          {
+            action: "Web Research, Gitlink, Virtual Environment Runner, HTML Renderer",
+            description:
+              "Plugin nodes. Each has its own controls and its own state, and each stays on the canvas as a record of what it did.",
+          },
+        ],
+      },
+    ],
   },
   {
-    "name": "Navigation",
-    "description": "Mouse, keyboard, search, command palette, and view controls for moving quickly through small or very large graphs.",
-    "subsections": [
+    name: "Finding Things",
+    description: "Six different search surfaces, and which one you actually want.",
+    subsections: [
       {
-        "title": "Mouse and View Controls",
-        "items": [
+        title: "Search",
+        items: [
           {
-            "action": "Pan the Canvas",
-            "description": "Hold the Middle Mouse Button and drag to move around the workspace. This is the fastest way to traverse large graphs once you stop thinking of the canvas like a normal chat window."
+            action: "Command palette",
+            description:
+              "Every action in the app, by name. If you cannot remember where a control lives, this is faster than remembering.",
+            keys: ["Ctrl+K"],
           },
           {
-            "action": "Zoom and Focus",
-            "description": "Use Ctrl + Mouse Wheel to zoom, or use the toolbar buttons when you want a fixed step. The command palette (Ctrl + K) also has Zoom In, Zoom Out, and Reset View entries."
+            action: "Canvas search",
+            description:
+              "Text inside the nodes of the graph you have open. Matches are highlighted in place and you can step between them.",
+            keys: ["Ctrl+F"],
           },
           {
-            "action": "Zoom to an Area",
-            "description": "Hold Shift and drag a rectangle to zoom the view to a specific region. It is a precise way to jump into a dense subsection of a large project."
+            action: "Quick switcher",
+            description: "Jump to another saved graph by fuzzy-matching its title.",
+            keys: ["Ctrl+P"],
           },
           {
-            "action": "Fit All and Reset",
-            "description": "Fit All reframes the canvas around everything currently on it, while Reset restores the default zoom level. These two actions are the quickest recovery tools when you get lost."
+            action: "Global Search",
+            description:
+              "Across every workspace and every ingested document at once - the one to use when you know you wrote it somewhere and not where.",
           },
           {
-            "action": "Minimap and Overlays",
-            "description": "Use the Controls toggle to reveal drag, grid, and font tools, and use the minimap to jump directly to distant nodes. This becomes more valuable as your project spreads out."
-          }
-        ]
+            action: "Knowledge",
+            description:
+              "Searches your ingested knowledge base and returns the exact passage, at the exact offset, with a link back to the source where one exists. Lexical always; also vector-based once an embedding model is configured.",
+          },
+        ],
       },
       {
-        "title": "Keyboard Workflow",
-        "items": [
+        title: "Orientation",
+        items: [
           {
-            "action": "Branch Navigation",
-            "description": "Ctrl + Arrow Keys move between parent, child, and sibling nodes in the current branch. This makes branch review much faster than constant mouse travel."
+            action: "Navigation pins",
+            description:
+              "Drop a pin on a spot worth returning to, give it a name, and jump back from the Pins list. Pins are marked on the canvas itself, so they are findable without opening the list.",
           },
           {
-            "action": "Command Palette",
-            "description": "Press Ctrl + K to open a searchable command palette for layout, note creation, selection, navigation, plugin insertion, chart generation, and more. It is the fastest way to discover power-user actions."
+            action: "Filters",
+            description:
+              "View, then Focus. Filter by node kind or by branch status to dim everything you are not looking at. Nothing is hidden or moved - the filter is a lens, and Clear takes it off.",
           },
-          {
-            "action": "Canvas Search",
-            "description": "Press Ctrl + F to search across chat, code, document, image, thinking, and plugin nodes. Search results can be stepped through so you can quickly revisit important content."
-          },
-          {
-            "action": "Selection Utilities",
-            "description": "Delete removes the current selection, and the command palette also exposes focus selection, select all, collapse all, and expand all. These commands are useful once a graph becomes visually dense."
-          }
-        ]
+        ],
       },
-      {
-        "title": "Shortcut Reference",
-        "items": [
-          {
-            "action": "Ctrl + T / Ctrl + L / Ctrl + S",
-            "description": "Start a new chat, open the Library, or save the current project. These are the main project-level shortcuts you will use most often."
-          },
-          {
-            "action": "Ctrl + G / Ctrl + Shift + G",
-            "description": "Wrap the current selection in a Frame, or create a Container. A new Note has no dedicated shortcut - use the command palette (Ctrl + K) instead."
-          },
-          {
-            "action": "Ctrl + Z / Ctrl + Shift + Z / Ctrl + Y",
-            "description": "Undo, or redo (either Ctrl + Shift + Z or Ctrl + Y works - both are wired). These are gated while a text field has focus, so they never shadow ordinary in-field text undo."
-          }
-        ]
-      }
-    ]
+    ],
   },
   {
-    "name": "Organization",
-    "description": "Ways to group, label, tidy, and visually manage complex canvases as a project grows.",
-    "subsections": [
+    name: "Organizing",
+    description: "Grouping, tidying, and making a large canvas legible.",
+    subsections: [
       {
-        "title": "Structuring Large Graphs",
-        "items": [
+        title: "Structure",
+        items: [
           {
-            "action": "Frames",
-            "description": "Select node-like items and press Ctrl + G to wrap them in a frame. Frames are best for labeling a visual section of the project without forcing the grouped items to move as one rigid unit."
+            action: "Frames",
+            description: "Wrap a selection in a labelled boundary. The nodes stay independent.",
+            keys: ["Ctrl+G"],
           },
           {
-            "action": "Containers",
-            "description": "Use Ctrl + Shift + G to create a container when a set of items should move together. Containers are useful for keeping a working cluster intact while you reorganize the rest of the canvas."
+            action: "Containers",
+            description:
+              "Group nodes so they move together. Use a container when the group is one thing; use a frame when it is several things about one subject.",
+            keys: ["Ctrl+Shift+G"],
           },
           {
-            "action": "Titles and Colors",
-            "description": "Frames and containers can be renamed and recolored so sections of the graph read like chapters or workstreams. This helps when you want the canvas to double as a presentation surface."
+            action: "Titles and colors",
+            description:
+              "Rename any node, and colour frames and containers. Colour is the fastest legend a large canvas can have, and it costs nothing to change later.",
           },
           {
-            "action": "Auto-Organize Tree Layout",
-            "description": "The Organize button arranges conversational and plugin branches into a cleaner horizontal tree. It is a fast way to recover readability after a burst of exploratory work."
-          }
-        ]
+            action: "Organize",
+            description:
+              "Lays the graph out as a tree. It moves things - if you have arranged the canvas deliberately, this will undo that arrangement, and Undo will bring it back.",
+          },
+        ],
       },
       {
-        "title": "Orientation Aids",
-        "items": [
+        title: "Appearance",
+        items: [
           {
-            "action": "Navigation Pins",
-            "description": "Pins mark important places on the canvas and are saved with the chat. Use the Pins toolbar button to reveal the overlay and jump back to major milestones or hotspots."
+            action: "The View panel",
+            description:
+              "Canvas, Grid, Connections, Node Font and Focus. Pan speed, snapping, grid spacing and style, connection routing, node typography and the focus filters all live here, with Reset to Defaults pinned at the bottom.",
           },
           {
-            "action": "Grid and Guide Controls",
-            "description": "The controls overlay can enable snap-to-grid, smart guides, orthogonal routing, font controls, and faded connections. These tools are useful when a canvas needs visual cleanup rather than new AI output."
+            action: "Snapping",
+            description:
+              "Snap to Grid lands dragged nodes on grid lines. Smart Guides aligns them to their neighbours instead. Both are off by default; pick one rather than both.",
           },
           {
-            "action": "Reduce Visual Noise",
-            "description": "Combine collapse, grouping, branch isolation, and layout tools to keep the graph readable. Graphlink works best when you treat organization as part of the thinking process, not just post-processing."
-          }
-        ]
-      }
-    ]
+            action: "Quieter connections",
+            description:
+              "Fade Connections dims every line except the one under the pointer. On a graph with a hundred edges this is the difference between a diagram and a hairball.",
+          },
+          {
+            action: "Collapse",
+            description:
+              "Most node types collapse to a title bar. A branch that is finished but still worth keeping connected is exactly what collapse is for. Nodes also collapse automatically when you zoom far enough out.",
+          },
+        ],
+      },
+    ],
   },
   {
-    "name": "Plugins & Tools",
-    "description": "Specialist nodes that extend a branch into research, reasoning, coding, drafting, rendering, and comparison workflows.",
-    "subsections": [
+    name: "Plugins",
+    description: "Specialist nodes, grouped the way the picker groups them.",
+    subsections: [
       {
-        "title": "Research and Analysis",
-        "items": [
+        title: "Branch Foundations",
+        items: [
           {
-            "action": "Graphlink-Web",
-            "description": "Use this when a branch depends on current information or external sources. The node runs a web retrieval flow, summarizes the findings, and stores source links directly in the result."
+            action: "System Prompt",
+            description:
+              "Overrides the system prompt for everything downstream of it. One branch can run under different instructions than its siblings, which is the cheapest A/B test in the app.",
           },
           {
-            "action": "Conversation Node",
-            "description": "Creates a self-contained linear chat surface inside the graph. Use it when you want a focused sub-conversation that can be pruned and iterated without expanding the main branch too aggressively."
-          }
-        ]
+            action: "Conversation Node",
+            description: "A self-contained linear chat, for when you do not want to branch.",
+          },
+        ],
       },
       {
-        "title": "Build, Draft, and Render",
-        "items": [
+        title: "Reasoning and Research",
+        items: [
           {
-            "action": "System Prompt",
-            "description": "Adds a branch-scoped system prompt note that changes assistant behavior only for that conversation path. This is ideal when you want a role, tone, or instruction change without affecting the rest of the project."
+            action: "Web Research",
+            description:
+              "Searches, retrieves and summarizes web sources with citations, under a bounded network policy. Results carry their sources, so a claim can be checked rather than taken.",
+          },
+        ],
+      },
+      {
+        title: "Build and Execution",
+        items: [
+          {
+            action: "Gitlink",
+            description:
+              "Loads a GitHub repository as structured context, prepares file-level changes, and writes nothing until you approve the diff.",
           },
           {
-            "action": "Virtual Environment Runner",
-            "description": "Runs Python in a per-node virtualenv with declared dependencies - the venv isolates installed packages, not the operating system; code still runs with your full account privileges. Use it for implementation, debugging, code generation, and dependency-aware, reproducible execution."
+            action: "Virtual Environment Runner",
+            description:
+              "Runs Python in an isolated virtualenv with per-node requirements. Read the isolation claim precisely: it isolates installed packages, not the operating system. Code runs with your user account's privileges.",
           },
           {
-            "action": "Artifact / Drafter",
-            "description": "A living markdown drafting surface for reports, specs, briefs, and other documents that need repeated revision. It is the most natural place to keep polished long-form output inside the graph."
+            action: "HTML Renderer",
+            description: "Renders HTML from a parent node so you can see the page, not the markup.",
           },
+        ],
+      },
+      {
+        title: "Workflow and Drafting",
+        items: [
           {
-            "action": "HTML Renderer",
-            "description": "Turns HTML or UI markup into a preview pane inside the graph and can pop the preview into a separate window. It is the right tool when a branch needs visual feedback instead of plain text output."
-          }
-        ]
-      }
-    ]
+            action: "Artifact / Drafter",
+            description:
+              "A split-pane node for drafting and refining a Markdown document over many turns.",
+          },
+        ],
+      },
+    ],
   },
   {
-    "name": "Builder",
-    "description": "An agent that plans a checklist for a goal, then constructs it on the canvas one supervised step at a time - the same tools you could use by hand, run for you.",
-    "subsections": [
+    name: "The Builder",
+    description: "An agent that plans a job as a checklist, then builds it on the canvas.",
+    subsections: [
       {
-        "title": "How a Build Works",
-        "items": [
+        title: "Starting a Build",
+        items: [
           {
-            "action": "Goal, Plan, Build",
-            "description": "Give the Builder a goal, or pick a saved recipe, and it drafts a short checklist first. The plan is a real node on the canvas - review it, edit it if you want, and only then start the build."
+            action: "Describe the goal",
+            description:
+              "A sentence or two of what you want built. The Builder turns it into a plan you can read and edit before anything runs - the plan is the point, and it is worth reading.",
           },
           {
-            "action": "What It Can Build",
-            "description": "Create and edit chat, note, code, document, and web research nodes; execute Python; generate charts and assistant replies from a node's content; run web research and search your knowledge base - the same actions available to you, driven for you."
+            action: "Recipes",
+            description:
+              "A saved goal and step list. Starting from one skips the planning pass entirely, because the checklist already exists. You can save any finished build as a recipe and delete your own again later.",
           },
           {
-            "action": "Oversight: Co-pilot vs. Autopilot",
-            "description": "Co-pilot asks you to approve every mutating step. Autopilot runs to completion within its budgets, creating and editing nodes and executing code without asking - network access still asks every time, in either mode."
+            action: "Co-pilot or Autopilot",
+            description:
+              "Co-pilot asks before every mutating step. Autopilot does not - it creates nodes and executes code without stopping, inside the budgets. Network access still asks either way. Choose Autopilot when you have read the plan and believe it.",
           },
           {
-            "action": "Budgets Are Hard Limits",
-            "description": "Steps, tokens, and time are capped before a build starts. A budget breach pauses the build with its state intact rather than losing progress - raise the limit and resume to pick up exactly where it stopped."
-          }
-        ]
+            action: "Budgets are hard limits",
+            description:
+              "Quick, Standard and Extended set steps, tokens and wall-clock time; the exact numbers are under Set exact limits. A breach pauses the build rather than failing it, so a paused run can be resumed once you have decided it is worth more.",
+          },
+        ],
       },
       {
-        "title": "The Plan Node",
-        "items": [
+        title: "While It Runs",
+        items: [
           {
-            "action": "Watch It Build",
-            "description": "The plan node shows each step's status live, plus an expandable activity log of every tool call the build made and whether it succeeded."
+            action: "Watch the checklist",
+            description:
+              "The running step is highlighted on the plan card, spent budgets are shown against their limits, and every tool call the run has made is listed - including the ones that failed.",
           },
           {
-            "action": "Pause, Stop, and Resume",
-            "description": "A build can be stopped at any time. A paused, stopped, or failed build resumes from exactly where it left off - even after restarting the app, since the plan node itself is the resume point."
+            action: "Edit the plan",
+            description:
+              "Steps can be retitled, reordered and removed while the build is startable or paused. Steps that have already run are history and cannot be rewritten.",
           },
           {
-            "action": "Undo a Build",
-            "description": "Once a build finishes or stops, Undo Build reverts everything it did in one action, the same as undoing any other change."
+            action: "Stopping is permanent",
+            description:
+              "Pausing and interruptions can be resumed. Stop cannot - a stopped build is over, and the way forward is Undo build or a new one. This is deliberate, and the card says so before you press it.",
           },
           {
-            "action": "Save and Reuse Recipes",
-            "description": "Turn a finished build's plan into a reusable recipe from its own node's Save as Recipe action. A saved recipe can be deleted from the launcher when you no longer need it - built-in recipes cannot be removed."
-          }
-        ]
-      }
-    ]
+            action: "Undo build",
+            description:
+              "Reverses what the build did, back as far as the first thing you changed yourself afterwards. Your own later edits survive.",
+          },
+        ],
+      },
+    ],
   },
   {
-    "name": "Agent",
-    "description": "An agent that works inside a folder - reading, writing, running commands - over as many steps as the task needs, and answers on the canvas.",
-    "subsections": [
+    name: "The Agent",
+    description: "An agent that works inside a real folder on your machine.",
+    subsections: [
       {
-        "title": "Starting One",
-        "items": [
+        title: "Setting One Up",
+        items: [
           {
-            "action": "Task and Workspace",
-            "description": "Open Agent, describe the task, and choose the folder it should work in. Choosing the folder in the launcher is what grants access to it - pick nothing and the agent gets a private scratch folder of its own instead."
+            action: "Task and workspace",
+            description:
+              "Describe the job, then choose where it happens. The default is a private scratch folder. Choosing one of your own folders is what grants access to it - the agent cannot reach outside the folder it is bound to.",
           },
           {
-            "action": "What It Can Do",
-            "description": "Read, write, and search files in its workspace; run shell commands and Python there; keep long-running processes open; search your knowledge base; delegate read-only lookups to subagents; and build on the canvas it lives in."
+            action: "What it can do",
+            description:
+              "Read and write files in its workspace, run shell commands and Python there, and search your knowledge base. It works in turns and reports back on the canvas.",
           },
           {
-            "action": "Turn Budget",
-            "description": "Max turns is a hard limit on model turns for one task. Hitting it stops the task with everything it did intact - send a follow-up to continue from there."
+            action: "Turn budget",
+            description:
+              "A hard cap on how many turns one task gets. The run stops when it is reached, which is the backstop against an agent that has misunderstood the job and is busy being thorough about it.",
           },
           {
-            "action": "AGENTS.md",
-            "description": "A file named AGENTS.md at the workspace root joins the agent's instructions, so a folder can carry its own conventions. It is reference material only: it cannot grant a capability or waive an approval."
-          }
-        ]
+            action: "AGENTS.md",
+            description:
+              "If the workspace has one, the agent reads it. Project conventions belong there rather than in every task description.",
+          },
+        ],
       },
       {
-        "title": "Working With One",
-        "items": [
+        title: "Working With It",
+        items: [
           {
-            "action": "Approvals",
-            "description": "Anything that changes your machine asks first, showing the exact command or file content. Approve once, or allow that tool for the rest of the session - except for commands that cannot be undone, which always ask again."
+            action: "Approvals",
+            description:
+              "Anything that changes your machine asks first, showing the exact command or file write. Deny is the focused default. Some tools can be approved for the whole session; the ones that run arbitrary code cannot, by design.",
           },
           {
-            "action": "Watch It Work",
-            "description": "The card shows a live checklist when the agent keeps one, an activity log of every tool call, and how much of its context budget the conversation fills. When it needs you, the status says so."
+            action: "It can ask you things",
+            description:
+              "When the agent needs a decision it parks and waits, and the card gives you a box to answer in. A parked agent is not a stuck one.",
           },
           {
-            "action": "Answer, Follow Up, and Stop",
-            "description": "The agent can stop and ask you a question mid-run. Once a task ends - done, stopped, or failed - send a follow-up to keep the same conversation going; its history lives with its workspace, so it survives a restart."
+            action: "Follow up",
+            description:
+              "Send another instruction to a finished agent and it picks up with its workspace and history intact.",
           },
           {
-            "action": "The Agent vs. the Builder",
-            "description": "The Builder constructs nodes on the canvas from a plan you approve. The Agent works in a real folder on disk and reports back. Reach for the Agent when the work is files and commands, not canvas structure."
-          }
-        ]
-      }
-    ]
+            action: "Agent or Builder?",
+            description:
+              "The Builder builds a graph - nodes, charts, documents, on the canvas. The Agent changes files in a folder. If the output is something you want to read here, use the Builder; if it is something you want on disk, use the Agent.",
+          },
+        ],
+      },
+    ],
   },
   {
-    "name": "Settings & Models",
-    "description": "How runtime modes, providers, model routing, and quality-of-life settings shape the behavior of the application.",
-    "subsections": [
+    name: "Models and Settings",
+    description: "Providers, per-task routing, and the settings worth knowing about.",
+    subsections: [
       {
-        "title": "Runtime Modes",
-        "items": [
+        title: "Where Models Come From",
+        items: [
           {
-            "action": "Ollama (Local)",
-            "description": "Use local Ollama when you want on-device chat and reasoning. You can choose a default chat model and set a reasoning level - Off, Low, Medium, or High - to control how much the model thinks before responding."
+            action: "Ollama and Llama.cpp",
+            description:
+              "Local models, each with its own Settings page. Nothing leaves the machine. Both scan for installed models rather than making you type an identifier.",
           },
           {
-            "action": "API Endpoint Mode",
-            "description": "Use API Endpoint mode for OpenAI-compatible providers or Gemini. This unlocks hosted models, per-task model routing, and the image-generation path used by the canvas."
+            action: "API Endpoint",
+            description:
+              "OpenAI-compatible providers and Gemini. This is also the path that image generation runs on - local providers have none.",
           },
           {
-            "action": "Per-Task Model Selection",
-            "description": "Graphlink can store different models for title generation, main chat, chart generation, image generation, web validation, and web summarization. This lets you optimize cost and quality across different tools."
-          }
-        ]
+            action: "Per-task routing",
+            description:
+              "Chat, chat naming, chart generation, web validation and web summarization can each use a different model, and the API path adds image generation. The naming model is the one to make cheap: it writes titles and runs constantly.",
+          },
+          {
+            action: "Routing preference",
+            description:
+              "Cheapest Capable, Fastest or Best Quality, for tasks that are set to choose automatically rather than pinned to a model.",
+          },
+        ],
       },
       {
-        "title": "Personalization and Feedback",
-        "items": [
+        title: "Worth Knowing",
+        items: [
           {
-            "action": "Token Counter",
-            "description": "When enabled, the token counter estimates how many tokens your current draft will use before you send it. It is useful for keeping an eye on how large a request is getting."
+            action: "Reasoning level",
+            description:
+              "Off, Low, Medium or High, in the composer, per message. Higher levels think longer and cost more; High on a question that did not need it is the most common way to waste tokens here.",
           },
           {
-            "action": "Provider-Specific Guidance",
-            "description": "API settings explain which providers are supported and which fields matter for each one. OpenAI-compatible endpoints and Gemini use slightly different setup and model-loading paths."
+            action: "Token counter",
+            description:
+              "Estimates what the draft in the composer will cost before you send it. An estimate, not an invoice.",
           },
           {
-            "action": "Optional Feature Dependencies",
-            "description": "Some features rely on optional libraries, such as PDF or DOCX import-export support and HTML preview support. When something is unavailable, Graphlink tries to tell you what dependency is missing."
-          }
-        ]
-      }
-    ]
+            action: "Resource limits",
+            description:
+              "Caps on what executed code may consume. They apply to plugin runs, sandboxes and agents alike, including under Autopilot.",
+          },
+          {
+            action: "MCP servers and integrations",
+            description:
+              "Connect external tools through their own Settings pages. What a connected server exposes becomes available to agents - worth knowing before connecting one you have not read.",
+          },
+          {
+            action: "Theme",
+            description: "Match System, Light or Dark. The canvas follows.",
+          },
+          {
+            action: "Optional dependencies",
+            description:
+              "PDF and DOCX handling and HTML preview need libraries that may not be installed. When one is missing the app names it rather than failing quietly.",
+          },
+        ],
+      },
+    ],
   },
   {
-    "name": "Saving & Output",
-    "description": "Persistence, attachments, exports, and the ways Graphlink turns branch results into reusable project deliverables.",
-    "subsections": [
+    name: "Saving and Output",
+    description: "Persistence, attachments, and getting work back out.",
+    subsections: [
       {
-        "title": "Persistence and Library",
-        "items": [
+        title: "Saving",
+        items: [
           {
-            "action": "Background Saves",
-            "description": "Use Save to persist the current graph, including chats, plugin nodes, notes, pins, frames, containers, and view state. This makes it practical to treat a chat like a reusable workspace instead of a disposable session."
+            action: "Save",
+            description:
+              "Writes the current graph to the Library. Work is also saved in the background as you go, so Save is a bookmark more than a rescue.",
+            keys: ["Ctrl+S"],
           },
           {
-            "action": "Chat Library",
-            "description": "Open the Library with the toolbar or Ctrl + L to reopen, rename, organize, or continue past projects. The Library is the main entry point for resuming work across sessions."
+            action: "Library",
+            description:
+              "Every saved graph, grouped by when you touched it, with a preview of its last message. Rename and delete are per row.",
+            keys: ["Ctrl+L"],
           },
           {
-            "action": "Local Project Record",
-            "description": "Because the graph is saved as a full project state, your canvas can function as a working notebook, task map, and decision trail all at once."
-          }
-        ]
+            action: "It is all local",
+            description:
+              "Graphs, attachments and knowledge are stored on your machine. Nothing is uploaded except what you send to whichever model provider you have configured.",
+          },
+        ],
       },
       {
-        "title": "Attachments and Exports",
-        "items": [
+        title: "In and Out",
+        items: [
           {
-            "action": "Supported Attachments",
-            "description": "You can attach common text and code files, JSON, CSV, XML, HTML, CSS, JS, and Markdown. PDF and DOCX attachments are also supported when their reader libraries are installed."
+            action: "Attachments",
+            description:
+              "Drop files onto the canvas or attach them in the composer. Text, documents, code and images all become nodes you can branch from.",
           },
           {
-            "action": "Drag and Drop",
-            "description": "Files can be staged by dragging them onto the canvas or by using the paperclip button. The attachment becomes a visible branch node so it is clear what source material was provided."
+            action: "Export PNG",
+            description:
+              "The whole canvas as an image - the fastest way to show someone the shape of a project without giving them the project.",
           },
           {
-            "action": "Export Formats",
-            "description": "Chat, document, and code content can be exported in practical formats such as TXT, Markdown, HTML, and PDF. Chat and document content also support DOCX, and code can be exported as a Python script."
+            action: "Copy anything",
+            description:
+              "Code blocks, replies and document text all copy out cleanly. A graph is a place to think, not a place work gets trapped.",
           },
-          {
-            "action": "Generated Outputs",
-            "description": "Image generation, chart creation, takeaway notes, explainers, group summaries, and branch diff notes all let you promote transient AI output into reusable project artifacts."
-          }
-        ]
-      }
-    ]
+        ],
+      },
+    ],
   },
   {
-    "name": "Use Cases",
-    "description": "Practical ways to use the full application beyond simple back-and-forth prompting.",
-    "subsections": [
+    name: "Keyboard",
+    description: "Every global shortcut. All of them are Ctrl on Windows and Linux, Cmd on macOS.",
+    subsections: [
       {
-        "title": "Common Workflows",
-        "items": [
-          {
-            "action": "Research and Comparison",
-            "description": "Start with a broad question, branch different answers, use Graphlink-Web to ground facts, and finish with Branch Lens when you want a disciplined comparison between competing paths."
-          },
-          {
-            "action": "Coding and Debugging",
-            "description": "Ask for code on the main canvas, then move promising results into a Virtual Environment Runner node to iterate, install dependencies, and run it for real. This keeps ideation and execution connected."
-          },
-          {
-            "action": "Planning and Execution",
-            "description": "Use Workflow Architect when a goal feels large or undefined. It can convert a vague request into a clearer plugin sequence so your next few steps are already framed."
-          },
-          {
-            "action": "Shipping and Hardening",
-            "description": "When a branch is close to done, run Quality Gate to judge whether it actually meets the bar. It is especially useful before handoff, release, demos, or any moment when confidence matters more than momentum."
-          },
-          {
-            "action": "Long-Form Writing",
-            "description": "Keep source research nearby, use reasoning where needed, and let Artifact / Drafter hold the polished document. This is a strong workflow for specs, reports, proposals, and internal documentation."
-          }
-        ]
+        title: "Project",
+        items: [
+          { action: "New chat", description: "Starts a fresh graph.", keys: ["Ctrl+T"] },
+          { action: "Open the Library", description: "Your saved graphs.", keys: ["Ctrl+L"] },
+          { action: "Save", description: "Writes the current graph to the Library.", keys: ["Ctrl+S"] },
+        ],
       },
       {
-        "title": "Knowledge Work Patterns",
-        "items": [
+        title: "Finding",
+        items: [
+          { action: "Command palette", description: "Every action, by name.", keys: ["Ctrl+K"] },
+          { action: "Search this graph", description: "Text inside the nodes on screen.", keys: ["Ctrl+F"] },
+          { action: "Quick switcher", description: "Jump to another saved graph.", keys: ["Ctrl+P"] },
+        ],
+      },
+      {
+        title: "Editing",
+        items: [
           {
-            "action": "Meeting and Study Notes",
-            "description": "Generate takeaways, explainer notes, and group summaries around important nodes so the final canvas reads like a structured knowledge map rather than a raw transcript dump."
+            action: "Undo",
+            description: "The undo stack is owned by the backend, so it outlasts a lot.",
+            keys: ["Ctrl+Z"],
           },
           {
-            "action": "Product and UX Exploration",
-            "description": "Branch alternative product directions, draft requirements, render HTML prototypes, and compare variants without losing the reasoning that led to each option."
+            action: "Redo",
+            description: "Both spellings are wired - use whichever your hands already know.",
+            keys: ["Ctrl+Shift+Z", "Ctrl+Y"],
           },
           {
-            "action": "Data Storytelling",
-            "description": "Turn a branch that contains numbers or structure into charts, then keep the explanation, source inputs, and conclusions beside the visualization on the same canvas."
+            action: "Frame the selection",
+            description: "A labelled boundary around what is selected.",
+            keys: ["Ctrl+G"],
           },
           {
-            "action": "Prompt Variation by Branch",
-            "description": "Use System Prompt nodes and branching to test different assistant behaviors against the same underlying project. This is especially useful when you want to compare tone, role, or working style."
-          }
-        ]
-      }
-    ]
-  }
+            action: "Container from the selection",
+            description: "A group that moves as one.",
+            keys: ["Ctrl+Shift+G"],
+          },
+        ],
+      },
+      {
+        title: "Branches",
+        items: [
+          {
+            action: "Move through the branch",
+            description: "Parent, child and siblings of the selected node.",
+            keys: ["Ctrl+←", "Ctrl+→"],
+          },
+          { action: "Compare branches", description: "Two side by side.", keys: ["Ctrl+Shift+C"] },
+          {
+            action: "Synthesize branches",
+            description: "Merge what survived comparison into one result.",
+            keys: ["Ctrl+Shift+M"],
+          },
+        ],
+      },
+      {
+        title: "In a Text Field",
+        items: [
+          {
+            action: "Shortcuts stand down",
+            description:
+              "While a text field has focus, editing keys go to the field. Ctrl+Z undoes your typing, not the graph. The exceptions are deliberate: Ctrl+S saves and Ctrl+K opens the palette from anywhere, because both are reflexes worth honouring mid-sentence.",
+          },
+        ],
+      },
+    ],
+  },
 ];

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -251,52 +251,6 @@ body,
   background-color: var(--gl-surface-window);
 }
 
-/* ADR-012 stage 12.6: the empty-canvas hint - a fresh session's blank scene
-   otherwise looks indistinguishable from a broken one. Centered flex column
-   over the full canvas, same layout shape as .scene-bridge-error above (a
-   proven "replace/annotate the whole canvas region" pattern in this file),
-   but layered ON TOP of a working canvas rather than instead of a broken
-   one, so pointer-events is none on the wrapper - panning/the double-click-
-   to-create-node gesture on .scene-canvas underneath must keep working -
-   with only the button itself opting back in so it stays clickable. */
-.scene-empty-hint {
-  position: absolute;
-  inset: 0;
-  z-index: var(--gl-z-canvas-hud);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  padding: 32px;
-  text-align: center;
-  pointer-events: none;
-}
-
-.scene-empty-hint-text {
-  margin: 0;
-  max-width: 360px;
-  font-size: 13px;
-  color: var(--gl-surface-text-muted);
-}
-
-.scene-empty-hint-button {
-  padding: 6px 14px;
-  font-size: 12px;
-  font-weight: 600;
-  font-family: inherit;
-  color: var(--gl-surface-text-primary);
-  background-color: var(--gl-neutral-button-background);
-  border: 1px solid var(--gl-neutral-button-border);
-  border-radius: 6px;
-  cursor: pointer;
-  pointer-events: auto;
-}
-
-.scene-empty-hint-button:hover {
-  border-color: var(--gl-surface-border-strong, var(--gl-surface-text-muted));
-}
-
 .scene-node {
   min-width: 160px;
   background-color: var(--gl-surface-node-body);

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -4654,30 +4654,66 @@ mark.document-view-search-match-current {
   border-color: var(--gl-palette-selection);
 }
 
+/* -- Help panel body ------------------------------------------------------
+
+   Reference content, styled as reference content. Every item used to be its
+   own filled, rounded card: seventy identical grey boxes stacked down the
+   pane, which is a lot of ink spent saying "these things are separate" about
+   a list whose entries were never in danger of being confused for each
+   other. A card earns its box when it is a distinct object among unlike
+   neighbours. A run of like entries wants type and space instead - a name
+   that reads as a name, prose that reads as prose, and enough gap between
+   them to see where one stops.
+
+   The type sizes went up. Body copy sat at 11px in the MUTED token, which
+   is the treatment this design system uses for captions and hints - fine
+   for a one-line tooltip under a checkbox, and the wrong instrument for the
+   only long-form reading surface in the app. */
+
 .help-rail {
   width: 220px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   padding: 14px;
   overflow-y: auto;
   border-right: 1px solid var(--gl-surface-border);
 }
 
-.help-rail-intro {
-  margin: 0 0 4px;
-  font-size: 11px;
-  line-height: 1.4;
+/* Search over browse. A query replaces the section list's job rather than
+   narrowing inside it - see HelpDialog.tsx's own note on why the two are
+   not allowed to run at once. */
+.help-search {
+  box-sizing: border-box;
+  width: 100%;
+  height: 30px;
+  padding: 0 10px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-surface-field, var(--gl-surface-inset));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 7px;
+}
+
+.help-search::placeholder {
   color: var(--gl-surface-text-muted);
+}
+
+.help-search:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 1px;
 }
 
 .help-rail-buttons {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
+/* Hover and selected were the same fill, so the pointer made every row look
+   like the current one. They step now: idle, hover, selected. */
 .help-rail-button {
   box-sizing: border-box;
   width: 100%;
@@ -4686,22 +4722,30 @@ mark.document-view-search-match-current {
   font: inherit;
   font-size: 12px;
   font-weight: 600;
-  color: var(--gl-surface-text-muted);
+  color: var(--gl-surface-text-secondary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: 7px;
   cursor: pointer;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    color var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
 .help-rail-button:hover {
-  background-color: var(--gl-neutral-button-hover);
+  background-color: var(--gl-neutral-button-background);
   color: var(--gl-surface-text-primary);
+}
+
+.help-rail-button:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: -1px;
 }
 
 .help-rail-button.active {
   background-color: var(--gl-neutral-button-hover);
-  border-color: var(--gl-surface-border);
-  color: var(--gl-surface-text-primary);
+  border-color: var(--gl-neutral-button-border);
+  color: var(--gl-surface-text-bright);
 }
 
 .help-content {
@@ -4709,7 +4753,7 @@ mark.document-view-search-match-current {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  padding: 16px 20px;
+  padding: 18px 22px;
   overflow-y: auto;
   /* Some Help sections overflow and get a scrollbar, others don't - without
      reserving the gutter unconditionally, every click between them shifted
@@ -4718,56 +4762,111 @@ mark.document-view-search-match-current {
 }
 
 .help-content-title {
-  margin: 0 0 4px;
-  font-size: 16px;
+  margin: 0 0 5px;
+  font-size: 17px;
   font-weight: 700;
-  color: var(--gl-surface-text-primary);
+  letter-spacing: -0.01em;
+  color: var(--gl-surface-text-bright);
 }
 
 .help-content-description {
-  margin: 0 0 14px;
-  font-size: 12px;
-  color: var(--gl-surface-text-muted);
+  margin: 0 0 20px;
+  max-width: 62ch;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--gl-surface-text-secondary);
 }
 
 .help-scroll-area {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 22px;
 }
 
 .help-section-block {
   display: flex;
   flex-direction: column;
-  gap: 8px;
 }
 
 .help-section-title {
-  margin: 0;
-  font-size: 12px;
+  margin: 0 0 12px;
+  padding-bottom: 8px;
+  font-size: 10px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.14em;
   color: var(--gl-surface-text-muted);
+  border-bottom: 1px solid var(--gl-surface-border);
 }
 
-.help-item-card {
-  padding: 8px 10px;
-  background-color: var(--gl-neutral-button-hover);
-  border-radius: 8px;
+.help-item + .help-item {
+  margin-top: 16px;
 }
 
 .help-item-action {
-  margin: 0 0 2px;
-  font-size: 12px;
-  font-weight: 650;
-  color: var(--gl-surface-text-primary);
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 3px;
 }
 
+.help-item-name {
+  font-size: 12.5px;
+  font-weight: 650;
+  color: var(--gl-surface-text-bright);
+}
+
+/* Measure, not width. The content column is ~560px, which at this size is
+   well past the point where the eye starts losing its place between lines. */
 .help-item-description {
   margin: 0;
-  font-size: 11px;
+  max-width: 62ch;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--gl-surface-text-secondary);
+}
+
+/* Only in search results: which section and subsection this entry came
+   from, since a result list has no headings to sit under. */
+.help-item-context {
+  margin: 4px 0 0;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   color: var(--gl-surface-text-muted);
+}
+
+/* A key chord, drawn as a key. Shortcuts used to be spelled into the item's
+   own title in prose, where they carried no more weight than the words
+   around them - the one kind of content on this page that is scanned rather
+   than read. */
+.help-item-keys {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.help-item-keys-or {
+  margin-right: 6px;
+  font-size: 10px;
+  color: var(--gl-surface-text-muted);
+}
+
+.help-kbd {
+  display: inline-block;
+  padding: 2px 7px;
+  font-family: inherit;
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-surface-inset);
+  border: 1px solid var(--gl-surface-border-strong);
+  border-bottom-width: 2px;
+  border-radius: 5px;
 }
 
 /* -- Plugin picker popover (R2.5c) ----------------------------------------- */

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1998,22 +1998,68 @@ body,
   text-align: center;
 }
 
-/* -- View popover -------------------------------------------------------- */
+/* -- View popover ---------------------------------------------------------
+
+   A settings PANEL that opens as a popover, which is what its layout has to
+   admit: five sections and roughly twenty-five controls, taller than the
+   popover can be at any window size. So it is built as a fixed shell - a
+   scrolling body with a pinned footer - rather than as one long scrolling
+   block with the reset button stranded at the end of it.
+
+   ONE SPACING SCALE, and only one, because the absence of one is most of
+   what read as sloppy here: 6px inside a field (its label to its control),
+   12px between fields, 16px plus a rule between sections. Every element
+   used to carry its own margin - 10 above a field row, 4 below a slider, 6
+   above a segment, 10 above a toggle - so nothing lined up with anything
+   and no gap meant the same thing twice. The rhythm is now a single owl
+   rule on .view-section with two documented exceptions. */
 
 .view-popover {
   width: 300px;
   max-height: min(72vh, 720px);
+  display: flex;
+  flex-direction: column;
+  /* Padding moves to the scroller and the footer so the footer's rule can
+     span the full panel width, and overflow moves to the scroller so the
+     footer stays put. Both override .overlay-popover's own defaults, which
+     they can: this rule is later in the file. */
+  padding: 0;
+  overflow: hidden;
+}
+
+.view-scroll {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
+  padding: 12px 14px;
 }
 
 .view-section + .view-section {
-  margin-top: 14px;
-  padding-top: 12px;
+  margin-top: 16px;
+  padding-top: 14px;
   border-top: 1px solid var(--gl-surface-border);
 }
 
+/* The one rhythm rule. Fields, toggles and rows all inherit it; the two
+   exceptions below are places where a tighter pairing is the point.
+
+   The margin RESET is half the rule and has to live here rather than on
+   each child: `.view-section > * + *` and a bare `.view-subsection-title`
+   have identical specificity, so a `margin: 0` written on the child
+   silently cancelled the 12px for that child alone - which is exactly what
+   happened to the filter sub-headings, leaving them jammed against the
+   toggle above them while every other gap was correct. Zeroing every
+   child's UA margin up front, in the same rule that then adds the gap back,
+   removes the whole class of tie. */
+.view-section > * {
+  margin: 0;
+}
+
+.view-section > * + * {
+  margin-top: 12px;
+}
+
 .view-section-title {
-  margin: 0 0 8px;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.14em;
@@ -2024,28 +2070,39 @@ body,
 /* Section header that also carries an action (the filter Clear button). */
 .view-section-head {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
+  gap: 8px;
 }
 
 .view-subsection-title {
-  margin: 10px 0 4px;
   font-size: 10px;
   font-weight: 600;
+  letter-spacing: 0.04em;
   color: var(--gl-surface-text-label);
 }
 
-/* Label + live value readout above every slider - the redesign's core
-   idiom: no control without a name and a current value. */
+/* Exception 1: a sub-heading belongs to the row under it, not to the gap
+   above it. */
+.view-subsection-title + .view-row {
+  margin-top: 6px;
+}
+
+/* A field is one setting: its header, its control, and any scale marks
+   belonging to that control. Grouping them in an element is what lets the
+   rhythm rule above treat a whole setting as one unit. */
+.view-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* Label + live value readout above a control. */
 .view-field-row {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  margin-top: 10px;
-}
-
-.view-field-row:first-of-type {
-  margin-top: 0;
+  gap: 8px;
 }
 
 .view-field-label {
@@ -2053,15 +2110,19 @@ body,
   color: var(--gl-surface-text-secondary);
 }
 
+/* Exception 2: plain text, deliberately. This was a bordered, inset-filled
+   999px pill - pixel for pixel the shape of .view-chip, which is a BUTTON.
+   A read-only number that looks clickable is worse than an unstyled one, so
+   the readout now carries only what a readout needs: alignment, tabular
+   figures so it stops jittering as a slider moves, and enough contrast to
+   be the answer to "what is this set to". */
 .view-field-value {
-  font-size: 10px;
+  font-size: 10.5px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  padding: 1px 6px;
+  letter-spacing: 0.02em;
   color: var(--gl-surface-text-primary);
-  background-color: var(--gl-surface-inset);
-  border: 1px solid var(--gl-surface-border);
-  border-radius: 999px;
+  white-space: nowrap;
 }
 
 /* Sliders: styled track/thumb rather than the engine default, which reads
@@ -2071,31 +2132,43 @@ body,
   -webkit-appearance: none;
   appearance: none;
   width: 100%;
-  height: 18px;
-  margin: 4px 0 2px;
+  height: 14px;
+  margin: 0;
   background: transparent;
   cursor: pointer;
 }
 
+/* The track is FILLED to the current value. It used to be one flat bar, so
+   the only cue for where a setting sat was the thumb's position against
+   nothing - fine for one slider, unreadable for a column of them. The fill
+   width arrives as --view-slider-fill, set inline on the input by
+   SliderField: a custom property set on the input inherits into this
+   pseudo-element, which is the only way to paint progress on a range input
+   in this engine. */
 .view-slider::-webkit-slider-runnable-track {
   height: 4px;
-  border-radius: 2px;
-  background-color: var(--gl-neutral-button-border);
+  border-radius: 999px;
+  background-image: linear-gradient(
+    to right,
+    var(--gl-surface-text-secondary) 0 var(--view-slider-fill, 0%),
+    var(--gl-neutral-button-border) var(--view-slider-fill, 0%) 100%
+  );
 }
 
 .view-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 14px;
-  height: 14px;
-  margin-top: -5px;
+  width: 12px;
+  height: 12px;
+  margin-top: -4px;
   border-radius: 50%;
   background-color: var(--gl-surface-text-primary);
   border: 1px solid var(--gl-surface-border-strong);
   transition: transform var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
-.view-slider::-webkit-slider-thumb:hover {
+.view-slider:hover::-webkit-slider-thumb,
+.view-slider:focus-visible::-webkit-slider-thumb {
   transform: scale(1.15);
 }
 
@@ -2105,8 +2178,47 @@ body,
   border-radius: 4px;
 }
 
-/* Segmented control: one connected group for mutually-exclusive choices
-   (grid style, spacing presets, drag presets), replacing loose buttons. */
+/* The landmark values the backend publishes for a slider, drawn as marks on
+   that slider's own scale. They were a four-button segmented control
+   underneath the slider - a second, differently-shaped widget bound to the
+   same number, which is what made pan speed and grid spacing read as three
+   controls for one setting. As text marks they still set the value on
+   click, at a third of the height, and they read as part of the slider
+   rather than as a rival to it. */
+.view-ticks {
+  display: flex;
+  justify-content: space-between;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.view-tick {
+  font-size: 10px;
+  font-weight: 600;
+  font-family: inherit;
+  font-variant-numeric: tabular-nums;
+  padding: 0;
+  color: var(--gl-surface-text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color var(--gl-motion-fast) var(--gl-motion-ease);
+}
+
+.view-tick:hover {
+  color: var(--gl-surface-text-primary);
+}
+
+.view-tick.active {
+  color: var(--gl-surface-text-bright);
+}
+
+.view-tick:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
 /* A segmented control: a recessed track with one raised, selected segment.
    The track is what makes the selection readable - previously every segment
    carried the same --gl-neutral-button-background fill and the selected one
@@ -2117,7 +2229,6 @@ body,
    track -> hover -> selected. */
 .view-segment {
   display: flex;
-  margin-top: 6px;
   background-color: var(--gl-surface-inset);
   border: 1px solid var(--gl-neutral-button-border);
   border-radius: 6px;
@@ -2162,7 +2273,6 @@ body,
 .view-row {
   display: flex;
   gap: 4px;
-  margin-top: 6px;
   flex-wrap: wrap;
 }
 
@@ -2173,27 +2283,42 @@ body,
    (grid style, preset values) and is drawn as one connected control.
    Chips carry no single/multi-select meaning of their own: the filters
    are multi-select, the workspace tabs single-select, and both read
-   correctly because an active chip simply means "this one is on". */
+   correctly because an active chip simply means "this one is on".
+
+   Same inverted scale the segmented control had, and the same fix: active
+   was --gl-neutral-button-pressed, a step DARKER than the idle fill, so a
+   selected chip was the dimmest chip in the row and hovering an unselected
+   one lit it brighter than the selection. Idle -> hover -> active now steps
+   one way on both palettes. */
 .view-chip {
   font-size: 10px;
   font-weight: 600;
   font-family: inherit;
   padding: 3px 9px;
   color: var(--gl-surface-text-secondary);
-  background-color: var(--gl-neutral-button-background);
-  border: 1px solid var(--gl-neutral-button-border);
+  background-color: transparent;
+  border: 1px solid var(--gl-surface-border);
   border-radius: 999px;
   cursor: pointer;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    border-color var(--gl-motion-fast) var(--gl-motion-ease),
+    color var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
 .view-chip:hover {
-  background-color: var(--gl-neutral-button-hover);
+  background-color: var(--gl-neutral-button-background);
   color: var(--gl-surface-text-primary);
 }
 
+.view-chip:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 1px;
+}
+
 .view-chip.active {
-  background-color: var(--gl-neutral-button-pressed, var(--gl-neutral-button-hover));
-  border-color: var(--gl-surface-text-muted);
+  background-color: var(--gl-neutral-button-hover);
+  border-color: var(--gl-neutral-button-border);
   color: var(--gl-surface-text-bright);
 }
 
@@ -2201,17 +2326,23 @@ body,
   font-size: 10px;
   font-weight: 600;
   font-family: inherit;
-  padding: 1px 8px;
+  padding: 2px 8px;
   color: var(--gl-surface-text-secondary);
   background: none;
-  border: 1px solid var(--gl-neutral-button-border);
+  border: 1px solid var(--gl-surface-border);
   border-radius: 999px;
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .view-clear-btn:hover {
   color: var(--gl-surface-text-primary);
-  background-color: var(--gl-neutral-button-hover);
+  background-color: var(--gl-neutral-button-background);
+}
+
+.view-clear-btn:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 1px;
 }
 
 .view-color-swatch {
@@ -2229,6 +2360,11 @@ body,
    state. */
 .view-color-swatch:hover {
   border-color: var(--gl-surface-text-muted);
+}
+
+.view-color-swatch:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 2px;
 }
 
 .view-color-swatch.active {
@@ -2282,21 +2418,63 @@ body,
 .view-toggle-row {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  margin-top: 10px;
+  gap: 9px;
   cursor: pointer;
 }
 
+/* A drawn checkbox. These were the last engine-drawn controls in the panel:
+   an OS checkbox sitting beside a custom slider, a custom segmented control
+   and a custom swatch row, with `accent-color` doing what it could. The
+   native input stays - every bit of its keyboard and screen-reader
+   behaviour with it - and only the paint job is replaced. */
 .view-toggle-row input[type="checkbox"] {
+  appearance: none;
+  position: relative;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
   margin: 1px 0 0;
-  accent-color: var(--gl-surface-text-primary);
+  background: transparent;
+  border: 1px solid var(--gl-surface-border-strong);
+  border-radius: 4px;
   cursor: pointer;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    border-color var(--gl-motion-fast) var(--gl-motion-ease);
+}
+
+.view-toggle-row:hover input[type="checkbox"]:not(:checked) {
+  border-color: var(--gl-surface-text-muted);
+}
+
+.view-toggle-row input[type="checkbox"]:checked {
+  background-color: var(--gl-surface-text-primary);
+  border-color: var(--gl-surface-text-primary);
+}
+
+/* The tick, drawn from two borders on a rotated box - no glyph, so it
+   cannot pick up a fallback font's own idea of what a checkmark is. */
+.view-toggle-row input[type="checkbox"]:checked::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 3px;
+  height: 7px;
+  border: solid var(--gl-surface-window);
+  border-width: 0 1.6px 1.6px 0;
+  transform: rotate(45deg);
+}
+
+.view-toggle-row input[type="checkbox"]:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 2px;
 }
 
 .view-toggle-text {
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 2px;
 }
 
 .view-toggle-label {
@@ -2306,6 +2484,7 @@ body,
 
 .view-toggle-hint {
   font-size: 10px;
+  line-height: 1.4;
   color: var(--gl-surface-text-muted);
 }
 
@@ -2313,7 +2492,6 @@ body,
    the node card's own tokens so the sample sits on the same background the
    text will actually be read against. */
 .view-font-preview {
-  margin-top: 8px;
   padding: 8px 10px;
   background-color: var(--gl-surface-node-body);
   border: 1px solid var(--gl-surface-border);
@@ -2323,10 +2501,14 @@ body,
   white-space: nowrap;
 }
 
+/* Pinned, not trailing. This panel is taller than the popover at every
+   window size, so a footer inside the scroller meant scrolling past all
+   twenty-five controls to reach the one button that undoes them. */
 .view-footer {
-  margin-top: 14px;
-  padding-top: 12px;
+  flex-shrink: 0;
+  padding: 10px 14px;
   border-top: 1px solid var(--gl-surface-border);
+  background-color: var(--gl-surface-node-body);
 }
 
 .view-reset-btn {
@@ -2336,15 +2518,23 @@ body,
   font-family: inherit;
   padding: 6px 0;
   color: var(--gl-surface-text-secondary);
-  background-color: var(--gl-neutral-button-background);
-  border: 1px solid var(--gl-neutral-button-border);
+  background-color: transparent;
+  border: 1px solid var(--gl-surface-border);
   border-radius: 6px;
   cursor: pointer;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    color var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
 .view-reset-btn:hover {
-  background-color: var(--gl-neutral-button-hover);
+  background-color: var(--gl-neutral-button-background);
   color: var(--gl-surface-text-primary);
+}
+
+.view-reset-btn:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: 1px;
 }
 
 /* -- R2.3 composer + token counter + notification ------------------------ */


### PR DESCRIPTION
## Problem

The Help panel content was extracted from the Qt build and has not been updated since. Checked against the running app, it is wrong in five places and incomplete in several more.

Incorrect:

- "Controls toggle" - the control is named View.
- "Hold Shift and drag a rectangle to zoom the view to a specific region" - Shift-drag is rubber-band selection. No zoom-to-area gesture exists.
- Plugin listed as "Graphlink-Web" - the picker lists it as Web Research.
- Pan documented as middle-mouse only - left-drag on empty canvas also pans.
- Zoom documented as Ctrl+wheel - the wheel alone zooms.

Missing: Gitlink, Global Search, Knowledge, the quick switcher, node filters, branch status, and the Ctrl+P, Ctrl+Shift+C and Ctrl+Shift+M bindings.

The file header declared `GENERATED - do not hand-edit` and a count of 76 items. The file had been hand-edited and contained 88.

There were no tests covering the panel.

## Change

Content:

- Rewritten and re-sectioned to match the current app: Start Here, The Canvas, Node Types, Finding Things, Organizing, Plugins, The Builder, The Agent, Models and Settings, Saving and Output, Keyboard.
- "Use Cases" removed. Its three concrete entries moved into Start Here.
- Entries now state operational limits where they exist: Autopilot executes code without asking, a stopped build cannot be resumed, the sandbox isolates packages rather than the operating system, an agent is scoped to its bound folder.
- File header replaced with accurate maintenance guidance.

UI:

- Search added, matching entry titles, body text and key chords. A query replaces the section view rather than filtering within it.
- `keys` field added to `HelpItem`. Chords render as `<kbd>`, one command per entry, replacing chords spelled into item titles.
- Item cards replaced with a type-and-space list. Body copy raised off the 11px muted caption treatment, with a measure cap.
- Rail intro paragraph removed. Rail hover and selected states differentiated - they were the same fill. Dialog title changed from "Help Center" to "Help".

## Test plan

- `HelpDialog.test.tsx`, new, 15 tests: content invariants; every documented chord resolves through the real `resolveShortcut()`; every live binding is documented; regression guards for the three stale strings; section switching; `<kbd>` rendering; five search behaviours including the empty state and Escape handling.
- `npm run check` (schema drift, typecheck, lint, vitest, build, bundle size) against a clean checkout of this branch: 2080 pass.
- Manual: walked all eleven sections, searched by word and by chord, confirmed results carry section context and that selecting a section clears the query.
- Corrected facts verified in the running app: plain wheel zoom (100% to 152%), left-drag pan, and the plugin picker listing Web Research and Gitlink.

Stacked on #375.
