### PR TITLE
Make the default node font color follow the theme

### DIFF
--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -149,11 +149,20 @@ class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
     # ChatScene owned only the flag and the geometry ran in the view layer.
     smart_guides: bool = False
     drag_factor: float = 1.0
-    # Canvas font (ChatScene's setFontFamily/-Size/-Color state, R2): defaults
-    # match the legacy scene's own construction-time values.
+    # Canvas font (ChatScene's setFontFamily/-Size/-Color state, R2): family
+    # and size default to the legacy scene's own construction-time values.
+    # font_color's default is the EMPTY STRING, meaning "follow the theme":
+    # the frontend only writes --gl-node-font-color when this is non-empty,
+    # and the CSS falls back to var(--gl-surface-text-primary) otherwise
+    # (styles.css). The legacy default was a literal "#F0F0F0" - white-ish
+    # text chosen for the dark theme - which made every node body unreadable
+    # the moment the light palette was active, because a stored hex cannot
+    # adapt. Only an explicit user pick stores a hex now, and an explicit
+    # pick applies as-is in both themes, which is what "I chose this color"
+    # means.
     font_family: str = "Segoe UI"
     font_size_pt: int = 9
-    font_color: str = "#F0F0F0"
+    font_color: str = ""
     # R3.3: which chat node the Composer's next Send continues from - the
     # Qt-free stand-in for "the currently active branch" until real node
     # selection exists. None means the next message starts a fresh root.
@@ -2071,6 +2080,9 @@ class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
         if size_pt is not None:
             self.font_size_pt = max(FONT_SIZE_MIN, min(FONT_SIZE_MAX, int(size_pt)))
         if color is not None:
+            # "" is a valid value: reset to theme-following (see the field's
+            # own comment). Anything else is stored verbatim as the user's
+            # explicit choice.
             self.font_color = str(color)
 
     def set_view_state(self, zoom_factor: float, scroll_x: float, scroll_y: float) -> None:

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -2376,6 +2376,23 @@ def test_font_intents_use_bridge_slot_names_and_bound_values():
     asyncio.run(run())
 
 
+def test_font_color_defaults_to_theme_following_and_empty_resets_to_it():
+    # The default is the EMPTY string - "follow the theme" - not a hex. The
+    # old default was "#F0F0F0", a dark-theme white that made node text
+    # unreadable under the light palette; a stored hex cannot adapt, so only
+    # an explicit pick stores one. "" round-trips through setFontColor as the
+    # reset-to-theme value.
+    async def run():
+        bus, document, _ = make_bus()
+        assert document.scene_payload()["fontColor"] == ""
+        await bus.dispatch_intent("scene", "setFontColor", ["#9EC1E8"])
+        assert document.scene_payload()["fontColor"] == "#9EC1E8"
+        await bus.dispatch_intent("scene", "setFontColor", [""])
+        assert document.scene_payload()["fontColor"] == ""
+
+    asyncio.run(run())
+
+
 def test_organize_lines_up_disconnected_nodes_without_overlap():
     async def run():
         bus, document, _ = make_bus()

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -47,7 +47,9 @@ export const initialSceneState: SceneState = {
   dragFactor: 1,
   fontFamily: "Segoe UI",
   fontSizePt: 9,
-  fontColor: "#F0F0F0",
+  // "" = follow the theme (see useCanvasFontVars.ts); matches the backend
+  // default in backend/domain/graph.py.
+  fontColor: "",
   // ADR-010 stage 10.2: nothing is undoable before the first real scene
   // frame arrives - a fresh client has no history of its own, and the
   // backend's is what counts.

--- a/web_ui/src/app/canvas/useCanvasFontVars.test.tsx
+++ b/web_ui/src/app/canvas/useCanvasFontVars.test.tsx
@@ -1,0 +1,57 @@
+import { render } from "@testing-library/react";
+import { useRef } from "react";
+import { describe, expect, it } from "vitest";
+import { useCanvasFontVars } from "./useCanvasFontVars";
+
+/**
+ * The regression this pins: the node font color's default is "" - "follow
+ * the theme" - and the hook must translate that into the ABSENCE of
+ * --gl-node-font-color, so styles.css's fallback chain
+ * (var(--gl-node-font-color, var(--gl-surface-text-primary))) resolves to
+ * the active palette's text token. The old default was a stored "#F0F0F0",
+ * which rendered node text white-on-white the moment the light palette was
+ * active. Writing "" instead of removing the property would be the same
+ * bug in a new shape: an empty custom property is still a SET property,
+ * and var() substitution then takes the empty value over the fallback.
+ */
+
+/** Owns its ref (useRef, so the hook sees the same RefObject shape the
+ * real canvas wrapper passes) and reports the host element out through
+ * `onHost` so assertions can reach the real DOM node. */
+function Probe({ color, onHost }: { color: string; onHost: (el: HTMLDivElement) => void }) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  useCanvasFontVars(hostRef, "Segoe UI", 9, color);
+  return (
+    <div
+      ref={(el) => {
+        hostRef.current = el;
+        if (el) onHost(el);
+      }}
+    />
+  );
+}
+
+describe("useCanvasFontVars", () => {
+  it("writes an explicitly chosen color as-is", () => {
+    let host: HTMLDivElement | null = null;
+    render(<Probe color="#9EC1E8" onHost={(el) => (host = el)} />);
+    expect(host!.style.getPropertyValue("--gl-node-font-color")).toBe("#9EC1E8");
+  });
+
+  it('removes the property entirely for "" so the theme token wins', () => {
+    let host: HTMLDivElement | null = null;
+    const view = render(<Probe color="#9EC1E8" onHost={(el) => (host = el)} />);
+    view.rerender(<Probe color="" onHost={(el) => (host = el)} />);
+    // Removed, not set-to-empty: an empty value would still suppress the
+    // CSS fallback.
+    expect(host!.style.getPropertyValue("--gl-node-font-color")).toBe("");
+    expect([...host!.style]).not.toContain("--gl-node-font-color");
+  });
+
+  it("still writes family and size when the color is theme-following", () => {
+    let host: HTMLDivElement | null = null;
+    render(<Probe color="" onHost={(el) => (host = el)} />);
+    expect(host!.style.getPropertyValue("--gl-node-font-family")).toBe("Segoe UI");
+    expect(host!.style.getPropertyValue("--gl-node-font-size")).toBe("9pt");
+  });
+});

--- a/web_ui/src/app/canvas/useCanvasFontVars.ts
+++ b/web_ui/src/app/canvas/useCanvasFontVars.ts
@@ -37,6 +37,17 @@ export function useCanvasFontVars(
     // unit (1pt = 1/72in = 4/3px), not print-only, so this needs no
     // conversion - just the right unit suffix.
     el.style.setProperty("--gl-node-font-size", `${fontSizePt}pt`);
-    el.style.setProperty("--gl-node-font-color", fontColor);
+    // "" means "follow the theme": REMOVE the property rather than writing
+    // an empty value, so styles.css's own fallback chain -
+    // var(--gl-node-font-color, var(--gl-surface-text-primary)) - resolves
+    // to the active palette's text token in both themes. Writing "" would
+    // make the var() substitution take the empty value and drop the
+    // fallback. Only an explicit user pick writes a hex here, and an
+    // explicit pick applies as-is in both themes.
+    if (fontColor) {
+      el.style.setProperty("--gl-node-font-color", fontColor);
+    } else {
+      el.style.removeProperty("--gl-node-font-color");
+    }
   }, [wrapperRef, fontFamily, fontSizePt, fontColor]);
 }

--- a/web_ui/src/app/chrome/ViewPopover.test.tsx
+++ b/web_ui/src/app/chrome/ViewPopover.test.tsx
@@ -66,6 +66,9 @@ function makeStore(
     setFontFamily: vi.fn(),
     setFontSize: vi.fn(),
     setFontColor: vi.fn(),
+    // Reset to Defaults calls this; absent from the double it threw an
+    // unhandled TypeError the moment a test actually clicked Reset.
+    clearFilters: vi.fn(),
   };
   return {
     store,
@@ -236,5 +239,52 @@ describe("ViewPopover (ADR-012 stage 12.5 node filter)", () => {
 
     expect(toggleFilterStatus).toHaveBeenCalledWith("superseded");
     expect(toggleFilterKind).not.toHaveBeenCalled();
+  });
+});
+
+describe("ViewPopover font color (theme-following default)", () => {
+  // The stored value "" means "follow the theme" - node text inherits
+  // var(--gl-surface-text-primary) instead of a fixed hex, which is what
+  // keeps it readable when the palette flips. These pin the panel's half of
+  // that contract; useCanvasFontVars.test.tsx pins the canvas half.
+  it("shows Auto (not an empty hex) when the color is unset, and marks the Auto swatch active", () => {
+    const { store } = makeStore();
+    renderOpen(store);
+    expect(screen.getByText("Auto")).toBeInTheDocument();
+    const auto = screen.getByRole("button", { name: "Font color, Follow the theme" });
+    expect(auto).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("picking the Auto swatch commits the empty string through setFontColor", async () => {
+    const user = userEvent.setup();
+    const { store } = makeStore({ fontColor: "#9EC1E8" });
+    const setFontColor = store.setFontColor as ReturnType<typeof vi.fn>;
+    renderOpen(store);
+
+    await user.click(screen.getByRole("button", { name: "Font color, Follow the theme" }));
+    // The debounce (useDebouncedSetting, 120ms) has to flush before the
+    // intent fires.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(setFontColor).toHaveBeenCalledWith("");
+  });
+
+  it("an explicit color still shows its hex and leaves Auto unpressed", () => {
+    const { store } = makeStore({ fontColor: "#9ec1e8" });
+    renderOpen(store);
+    expect(screen.getByText("#9EC1E8")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Font color, Follow the theme" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("Reset to Defaults returns the font color to theme-following", async () => {
+    const user = userEvent.setup();
+    const { store } = makeStore({ fontColor: "#E3C577" });
+    const setFontColor = store.setFontColor as ReturnType<typeof vi.fn>;
+    renderOpen(store);
+
+    await user.click(screen.getByRole("button", { name: "Reset to Defaults" }));
+    expect(setFontColor).toHaveBeenCalledWith("");
   });
 });

--- a/web_ui/src/app/chrome/ViewPopover.tsx
+++ b/web_ui/src/app/chrome/ViewPopover.tsx
@@ -54,7 +54,9 @@ const DEFAULTS = {
   gridColor: "#555555",
   fontFamily: "Segoe UI",
   fontSizePt: 9,
-  fontColor: "#F0F0F0",
+  // "" = follow the theme - the backend default (backend/domain/graph.py).
+  // Reset returns to adaptive text, not to a dark-theme white.
+  fontColor: "",
 } as const;
 
 // The grid-size slider's range. The presets (10/20/50/100) remain the
@@ -227,21 +229,39 @@ function ToggleRow({
   );
 }
 
-/** Preset color swatches plus a free-choice picker at the end of the row. */
+/** Preset color swatches plus a free-choice picker at the end of the row.
+ * `autoLabel`, when given, prepends an "follow the theme" swatch that picks
+ * the empty string - the reset-to-adaptive affordance the font color needs
+ * (an unset font color inherits the palette's own text token and stays
+ * readable in both themes). Grid color has no such state and omits it. */
 function SwatchRow({
   presets,
   current,
   ariaPrefix,
+  autoLabel,
   onPick,
 }: {
   presets: readonly string[];
   current: string;
   ariaPrefix: string;
+  autoLabel?: string;
   onPick: (color: string) => void;
 }) {
   const currentIsPreset = presets.includes(current);
   return (
     <div className="view-row" role="group" aria-label={`${ariaPrefix} presets`}>
+      {autoLabel && (
+        <button
+          type="button"
+          className={"view-color-swatch view-color-auto" + (current === "" ? " active" : "")}
+          title={autoLabel}
+          aria-label={`${ariaPrefix}, ${autoLabel}`}
+          aria-pressed={current === ""}
+          onClick={() => onPick("")}
+        >
+          A
+        </button>
+      )}
       {presets.map((color) => (
         <button
           key={color}
@@ -265,7 +285,11 @@ function SwatchRow({
       >
         <input
           type="color"
-          value={current}
+          // A color input cannot hold "" - the browser coerces invalid
+          // values (to #000000, with a console warning). When the current
+          // value is "follow the theme" the picker just needs a sane
+          // starting point for the dialog it opens.
+          value={current || "#949494"}
           aria-label={`${ariaPrefix}, custom`}
           onChange={(e) => onPick(e.target.value)}
         />
@@ -493,11 +517,12 @@ export function ViewPopover({ store }: { store: SceneStore }) {
             onInput={setFontSizePt}
           />
           <div className="view-field">
-            <FieldRow label="Color" value={fontColor.toUpperCase()} />
+            <FieldRow label="Color" value={fontColor ? fontColor.toUpperCase() : "Auto"} />
             <SwatchRow
               presets={fontConfig.colorPresets}
               current={fontColor}
               ariaPrefix="Font color"
+              autoLabel="Follow the theme"
               onPick={setFontColor}
             />
           </div>
@@ -509,7 +534,9 @@ export function ViewPopover({ store }: { store: SceneStore }) {
             style={{
               fontFamily: scene.fontFamily,
               fontSize: `${fontSizePt}pt`,
-              color: fontColor,
+              // Unset = the palette's own text token, exactly what the
+              // canvas will render (useCanvasFontVars.ts).
+              color: fontColor || "var(--gl-surface-text-primary)",
             }}
           >
             The quick brown fox jumps over the lazy dog

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2563,6 +2563,30 @@ body,
   box-shadow: 0 0 0 1px var(--gl-surface-text-primary);
 }
 
+/* The "follow the theme" swatch at the head of the font-color row. Not a
+   color at all, so it is not drawn as one: the letter mark on the plain
+   surface says "automatic" where a filled square would falsely promise a
+   specific hue. Active means the stored value is "" and node text inherits
+   var(--gl-surface-text-primary) - the palette's own body-text token,
+   already held to WCAG AA by the token contrast test
+   (web_ui/src/lib/tokens/token-theme-contrast.test.ts), which is the whole
+   point of following the theme instead of storing a hex. */
+.view-color-auto {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-size: 11px;
+  font-weight: 700;
+  font-family: inherit;
+  color: var(--gl-surface-text-secondary);
+  background-color: var(--gl-surface-inset);
+}
+
+.view-color-auto.active {
+  color: var(--gl-surface-text-bright);
+}
+
 /* The free-choice picker at the end of each swatch row: a native color
    input hidden inside a swatch-shaped label, so picking a custom value
    looks and feels like picking a preset. The dashed border marks it as


### PR DESCRIPTION
## Problem

The canvas node font color is scene state (`font_color`, applied as `--gl-node-font-color` on the canvas wrapper by `useCanvasFontVars`). Its default was the literal `"#F0F0F0"` - a white chosen for the dark theme - so under the light palette every chat, thinking and markdown body rendered near-white text on white cards. A stored hex cannot adapt to a theme.

Reproduce on main: load any graph with the theme set to Match System and emulate `prefers-color-scheme: light`.

## Change

The default is now the empty string, meaning "follow the theme". An explicitly chosen color still stores its hex and applies as-is in both themes.

- `backend/domain/graph.py`: `font_color` defaults to `""`; `setFontColor("")` round-trips as the reset-to-theme value. `font_color` is in-memory session state with no persistence path, so there is no migration.
- `useCanvasFontVars.ts`: `""` removes `--gl-node-font-color` rather than writing an empty value, so the existing CSS fallback - `var(--gl-node-font-color, var(--gl-surface-text-primary))` - resolves to the active palette's body-text token, which the token contrast test already holds to WCAG AA in both themes. Writing `""` would suppress the fallback: an empty custom property is still a set property.
- `ViewPopover`: the font-color row gains a leading "follow the theme" swatch, active when unset; the readout shows `Auto` instead of an empty hex; the font preview falls back to the theme token; Reset to Defaults returns to `""` rather than to the dark-theme white; and the native color input is fed a valid hex when the stored value is empty (a color input coerces `""` to `#000000` with a console warning).

## Test plan

- `test_canvas.py`: new round-trip - default is `""`, an explicit hex stores, `""` resets. 326 backend canvas/migration tests pass.
- `useCanvasFontVars.test.tsx`, new: an explicit color is written as-is; `""` removes the property (asserted as absence, since an empty value would reintroduce the bug in a new shape); family and size still apply when the color is theme-following.
- `ViewPopover.test.tsx`: the Auto swatch renders and reads active when unset; picking it commits `""` through the debounce; an explicit color shows its hex with Auto unpressed; Reset commits `""`. Writing the Reset test exposed that the store double never mocked `clearFilters` - Reset threw an unhandled TypeError in jsdom - fixed in the double.
- `npm run check` against a clean checkout of this branch: 2135 pass. `pytest` for the touched backend suites and `ruff` clean.
- Verified live against the built bundle in both themes: dark renders `#E0E0E0` node text with no `--gl-node-font-color` set; flipping to light renders `#1F1F1F` on light cards; the View panel shows the active Auto swatch and `Auto` readout.
