### PR TITLE
Replace the composer's JS autosize with native field-sizing

### DIFF
--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import type { SceneStore } from "../canvas/sceneStore";
 import { Popover, useOverlays } from "../overlays/overlays";
 import type { ComposerStore } from "./composerStore";
@@ -62,7 +62,6 @@ export function Composer({
   const composer = useSyncExternalStore(store.subscribe, store.getComposer);
   const streamText = useSyncExternalStore(store.subscribe, store.getStreamText);
   const overlays = useOverlays();
-  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   // ADR-002 Workstream 1 ("Branch from here"): sceneStore's own
   // replyTargetNodeId/scene, subscribed here (not just in SceneCanvas) so
@@ -89,13 +88,6 @@ export function Composer({
     sceneStore.subscribe,
     sceneStore.getSynthesizeTargetNodeIds,
   );
-
-  useLayoutEffect(() => {
-    const input = inputRef.current;
-    if (!input) return;
-    input.style.height = "auto";
-    input.style.height = `${Math.max(42, Math.min(160, input.scrollHeight))}px`;
-  }, [composer.draft.text]);
 
   const modelLabel = composer.route.modelLabel || composer.route.modelId || "Select a model";
   const isSynthesizing = !!synthesizeTargetNodeIds && synthesizeTargetNodeIds.length > 0;
@@ -176,7 +168,6 @@ export function Composer({
       )}
       <div className="composer-input-wrap">
         <textarea
-          ref={inputRef}
           // ADR-012 stage 12.3: the skip-link's own jump target - see
           // App.tsx's ".skip-link" anchor, which lets a keyboard user bypass
           // every node on the canvas (an N-node canvas is otherwise N tab

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2993,6 +2993,15 @@ body,
 .composer-input {
   flex: 1;
   resize: none;
+  /* Native auto-size (same posture as .code-sandbox-node-input): the height
+     tracks the content continuously, so it can never go stale the way a
+     one-shot JS scrollHeight measurement could - that measurement was only
+     as good as the layout at the instant it ran. Chromium's UA sheet makes
+     textareas border-box, so these bounds match the old JS 42..160 range. */
+  field-sizing: content;
+  min-height: 42px;
+  max-height: 160px;
+  overflow-y: auto;
   font-family: inherit;
   font-size: 13px;
   line-height: 1.4;


### PR DESCRIPTION
## Problem

The composer textarea sized itself with a one-shot layout effect: reset `height` to `auto`, read `scrollHeight`, clamp to 42-160px, re-running only when the draft text changed. A `scrollHeight` read is only as good as the layout at the instant it runs, so any mount under a transient layout - a viewport resized after load, a zoom or DPI change - baked a wrong height into the inline style, and nothing corrected it until the next keystroke. In the failure mode this fix was traced from, an empty one-row composer rendered pinned at the 160px ceiling.

## Change

`field-sizing: content` on `.composer-input`, with `min-height: 42px` / `max-height: 160px` / `overflow-y: auto`. The height now tracks the content continuously instead of being sampled once, so it cannot go stale. Textareas are `border-box` in Chromium's UA sheet, so the bounds match the old JS 42-160 range exactly; this is the same native-autosize posture the code-sandbox card's inputs already use. The layout effect, the ref that existed only for it, and the now-unused `useLayoutEffect`/`useRef` imports are removed; the skip-link jump target is the element id and is unchanged.

## Test plan

- `Composer.test.tsx`: 38 pass unchanged.
- `npm run check` (schema drift, typecheck, lint, vitest, build, bundle size) against a clean checkout of this branch: 2135 pass.
- Manual against the built bundle at the app's real 1440x900 window: empty composer renders at the same geometry as before the change (textarea 50px, dock 114px, no inline height); a four-line draft grows it to ~81px and clearing returns it to 50px; two live viewport resizes with no reload leave it at 50px, the exact sequence that previously left the old implementation stuck at 160px.
