### PR TITLE
Rebuild the composer control rail

### DIFF
--- a/backend/composer.py
+++ b/backend/composer.py
@@ -63,6 +63,19 @@ DEFAULT_REASONING_LEVEL = "off"
 
 SEND_MODES = ("enter_to_send", "ctrl_enter_to_send")
 
+# pywebview validates each entry against `Name (*.ext;*.ext)` - the patterns
+# are SEMICOLON-separated (webview/util.py's parse_file_type). Space-separated
+# patterns raise ValueError at dialog-open time, so Attach crashed before a
+# dialog ever appeared. Module-level so the filter test can hold every entry
+# to the real parser.
+ATTACH_FILE_TYPES = (
+    "Common Attachments (*.png;*.jpg;*.jpeg;*.webp;*.mp3;*.wav;*.m4a;"
+    "*.flac;*.ogg;*.opus;*.aac;*.mp4;*.mpeg;*.mpga;*.oga;*.webm;*.pdf;"
+    "*.docx;*.txt;*.md;*.py;*.js;*.ts;*.json;*.csv;*.log)",
+    "Image Files (*.png;*.jpg;*.jpeg;*.webp)",
+    "All Files (*.*)",
+)
+
 
 class ComposerError(ValueError):
     """A composer intent referenced an invalid value."""
@@ -489,15 +502,7 @@ def register_composer(
         """
         from backend import native_dialogs
 
-        path = await native_dialogs.pick_file(
-            file_types=(
-                "Common Attachments (*.png *.jpg *.jpeg *.webp *.mp3 *.wav *.m4a "
-                "*.flac *.ogg *.opus *.aac *.mp4 *.mpeg *.mpga *.oga *.webm *.pdf "
-                "*.docx *.txt *.md *.py *.js *.ts *.json *.csv *.log)",
-                "Image Files (*.png *.jpg *.jpeg *.webp)",
-                "All Files (*.*)",
-            )
-        )
+        path = await native_dialogs.pick_file(file_types=ATTACH_FILE_TYPES)
         if not path:
             return
         try:

--- a/backend/tests/test_backend_composer.py
+++ b/backend/tests/test_backend_composer.py
@@ -743,3 +743,19 @@ def test_remove_attachment_removes_only_the_matching_id(tmp_path, monkeypatch):
 
     composer, keep_id = asyncio.run(run())
     assert [item.id for item in composer.staged_attachments] == [keep_id]
+
+
+def test_attach_file_types_are_valid_pywebview_filters():
+    """Every attach dialog filter must parse under pywebview's own grammar.
+
+    pywebview requires `Name (*.ext;*.ext)` - SEMICOLON-separated patterns
+    (webview/util.py's parse_file_type). The original tuple used spaces, so
+    every Attach click raised ValueError before a dialog appeared. Held to
+    the real parser, not a re-implementation of its regex, so a pywebview
+    grammar change fails here instead of at dialog-open time.
+    """
+    util = pytest.importorskip("webview.util")
+    from backend.composer import ATTACH_FILE_TYPES
+
+    for file_type in ATTACH_FILE_TYPES:
+        util.parse_file_type(file_type)  # raises ValueError if invalid

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -239,8 +239,10 @@ export function Composer({
           }
           onClick={() => overlays.toggle("reasoning", "popover")}
         >
-          <span className="control-kicker">Reasoning</span>
-          <span className="control-value">{composer.route.reasoning.label}</span>
+          <span className="composer-control-label">Reasoning</span>
+          <span className="composer-control-value composer-control-value-reasoning">
+            {composer.route.reasoning.label}
+          </span>
           <Icon name="chevron" />
         </button>
 
@@ -266,22 +268,23 @@ export function Composer({
           }
           onClick={() => overlays.toggle("model", "popover")}
         >
-          <span className="control-copy">
-            <span className="control-kicker">{composer.route.provider}</span>
-            <span className="control-value" title={modelLabel}>
-              {modelLabel}
-            </span>
+          <span className="composer-control-label">{composer.route.provider}</span>
+          <span className="composer-control-value composer-control-value-model" title={modelLabel}>
+            {modelLabel}
           </span>
           <Icon name="chevron" />
         </button>
 
-        {showTokenCounter && <TokenCounter store={store} />}
+        <div className="composer-rail-end">
+          {showTokenCounter && <TokenCounter store={store} />}
 
-        <div className="composer-send-group">
-          {composer.request.canCancel && (
+          {composer.request.canCancel ? (
+            // One primary slot, two states: while a response can still be
+            // cancelled the slot IS the stop control - Send never renders
+            // beside it as a competing (and necessarily disabled) twin.
             <button
               type="button"
-              className="composer-icon-button composer-cancel-button"
+              className="composer-send-button"
               onClick={() => {
                 if (composer.request.id) store.cancelChatRequest(composer.request.id);
               }}
@@ -290,18 +293,18 @@ export function Composer({
             >
               <Icon name="stop" />
             </button>
+          ) : (
+            <button
+              type="button"
+              className="composer-send-button"
+              disabled={!composer.draft.text.trim() || !composer.request.canSend}
+              title="Send message"
+              aria-label="Send message"
+              onClick={send}
+            >
+              <Icon name="send" />
+            </button>
           )}
-
-          <button
-            type="button"
-            className="composer-send-button"
-            disabled={!composer.draft.text.trim() || !composer.request.canSend}
-            title="Send message"
-            aria-label="Send message"
-            onClick={send}
-          >
-            <Icon name="send" />
-          </button>
         </div>
       </div>
 

--- a/web_ui/src/app/chrome/TokenCounter.tsx
+++ b/web_ui/src/app/chrome/TokenCounter.tsx
@@ -35,8 +35,8 @@ export function TokenCounter({ store }: { store: ComposerStore }) {
         aria-expanded={hovered}
         aria-label={`Token usage: ${counter.totalTokens} total`}
       >
-        <span className="control-kicker">Tokens</span>
-        <span className="control-value">{counter.totalTokens}</span>
+        <span className="composer-control-label">Tokens</span>
+        <span className="composer-control-value">{counter.totalTokens}</span>
       </button>
       {hovered && (
         <div className="token-counter-popout" role="status" aria-label="Token usage breakdown">

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2813,11 +2813,11 @@ body,
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 8px;
+  padding: 10px 10px 8px;
   box-sizing: border-box;
   background-color: var(--gl-surface-node-body);
   border: 1px solid var(--gl-surface-border);
-  border-radius: 14px;
+  border-radius: 16px;
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
   transition: border-color 120ms ease;
 }
@@ -3005,7 +3005,7 @@ body,
   font-family: inherit;
   font-size: 13px;
   line-height: 1.4;
-  padding: 6px 4px 2px;
+  padding: 4px 6px 2px;
   color: var(--gl-surface-text-primary);
   background-color: transparent;
   border: none;
@@ -3024,8 +3024,8 @@ body,
 .composer-controls {
   display: flex;
   align-items: center;
-  gap: 2px;
-  padding-top: 4px;
+  gap: 4px;
+  padding-top: 6px;
 }
 
 /* R8a: flat/borderless at rest, a soft filled circle only on hover - was a
@@ -3035,12 +3035,12 @@ body,
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: 28px;
+  height: 28px;
   color: var(--gl-neutral-button-icon);
   background-color: transparent;
   border: none;
-  border-radius: 6px;
+  border-radius: 999px;
   cursor: pointer;
   transition: background-color 100ms ease;
 }
@@ -3069,16 +3069,21 @@ body,
   stroke-linejoin: round;
 }
 
+/* The rail's quiet chips (Reasoning, Model, Tokens): ONE line of type per
+   chip - a muted label, then the value. The old anatomy stacked a 9px
+   all-caps kicker over the value inside every chip, which put six lines of
+   micro-typography on a 30px rail. */
 .composer-control {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 4px 8px;
+  gap: 6px;
+  height: 26px;
+  padding: 0 9px;
   font-family: inherit;
   color: var(--gl-surface-text-primary);
   background-color: transparent;
   border: none;
-  border-radius: 6px;
+  border-radius: 999px;
   cursor: pointer;
   transition: background-color 100ms ease;
 }
@@ -3094,45 +3099,40 @@ body,
 }
 
 .composer-control .icon {
-  width: 12px;
-  height: 12px;
+  width: 11px;
+  height: 11px;
   fill: none;
   stroke: currentColor;
   stroke-width: 1.8;
   stroke-linecap: round;
   stroke-linejoin: round;
-}
-
-.control-kicker {
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
   color: var(--gl-surface-text-muted);
-  text-transform: uppercase;
 }
 
-/* R8a (UI/UX issue list finding #7): was max-width, a cap rather than a
-   fixed size, so a shorter label (e.g. reasoning level "Off") left the
-   button narrower than a longer one ("Medium"), and the adjacent control
-   visibly shifted sideways every time the value changed. A fixed width
-   keeps both the Reasoning and Model controls one stable size regardless
-   of which option/model is currently selected - long model ids still
-   ellipsis-truncate via the properties below, they just no longer resize
-   the button itself while doing it. */
-.control-value {
-  font-size: 11px;
+.composer-control-label {
+  font-size: 10.5px;
+  color: var(--gl-surface-text-muted);
+  white-space: nowrap;
+}
+
+.composer-control-value {
+  font-size: 11.5px;
   font-weight: 600;
-  width: 140px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.control-copy {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 1px;
+/* R8a (UI/UX issue list finding #7), carried forward: fixed value widths,
+   not caps, so neither chip resizes - and shoves its neighbour sideways -
+   when the selected option changes ("Off" vs "Medium", short vs long model
+   id). Long values still ellipsis-truncate inside the fixed box. */
+.composer-control-value-reasoning {
+  width: 52px;
+}
+
+.composer-control-value-model {
+  width: 150px;
 }
 
 /* R4.4 token-streaming preview - replaces the old static
@@ -3160,24 +3160,20 @@ body,
   word-break: break-word;
 }
 
-/* R8a: the one seam in the whole rail - everything to its left is flat, so
-   the send/cancel zone reads as a distinct group without boxing every
-   control individually. */
-.composer-send-group {
+/* Right end of the rail: the quiet token readout, then the card's one
+   primary. No separator seam any more - with a single primary slot there
+   is no button group left to fence off. */
+.composer-rail-end {
   display: flex;
   align-items: center;
   gap: 6px;
   margin-left: auto;
-  padding-left: 8px;
-  border-left: 1px solid var(--gl-surface-border);
-}
-
-.composer-cancel-button {
-  color: var(--gl-semantic-status-error, var(--gl-neutral-button-icon));
 }
 
 /* The sole accent affordance on the card: solid fill + fully circular,
-   everything else on the rail is flat/borderless. */
+   everything else on the rail is flat/borderless. While a response is
+   cancellable the same slot renders as Stop (filled-square glyph) - state
+   is encoded in the glyph's shape, never in a color shift. */
 .composer-send-button {
   display: flex;
   align-items: center;
@@ -3263,7 +3259,7 @@ body,
   display: flex;
 }
 
-.token-counter-summary .control-value {
+.token-counter-summary .composer-control-value {
   min-width: 2ch;
   text-align: right;
 }


### PR DESCRIPTION
## Problem

The composer's control rail kept its straight-port anatomy. Every chip stacked a 9px all-caps kicker over its value - Reasoning, Model and Tokens together put six lines of micro-typography on one 30px row - and the model chip's two-deck label made the rail read as three small forms rather than one control strip. The attach button was a bare glyph with no resting shape. While a response streamed, the rail showed two competing controls at once: a stop icon beside a permanently disabled Send ghost, fenced off behind a separator.

Separately, the Attach button itself crashed before a dialog ever appeared: pywebview validates each `file_types` entry against `Name (*.ext;*.ext)` - semicolon-separated patterns - and all three composer filters separated their patterns with spaces, raising ValueError on every click.

## Change

- One line of type per control: each pill is a muted label followed by its value ("Reasoning High", "Ollama qwen3:14b", "Tokens 1,204"), fully rounded, flat at rest with a soft fill on hover. The fixed value widths are carried over, so a changed selection still never shoves its neighbour sideways.
- Attach is a round hover-circle anchored at the rail's left end.
- Send and Stop share one primary slot at the rail's right end: while `request.canCancel` the filled circle renders the stop glyph and cancels the request, otherwise it is Send. State is encoded in the glyph's shape, never a color shift, and the separator seam is gone with the button group it fenced.
- Dock radius 14px to 16px with slightly wider padding; the input, banners, attachment chips, popovers, and all intents/store wiring are unchanged beyond the slot swap.
- The attach dialog's filters are hoisted to a module-level `ATTACH_FILE_TYPES` with semicolon-separated patterns.

## Test plan

- `Composer.test.tsx`: 38 pass unchanged - including the cancel-slot contract (Stop present with `canCancel`, absent without, calls `cancelChatRequest` with the request id) and every send-gating case.
- `test_backend_composer.py`: new regression test holds every `ATTACH_FILE_TYPES` entry to pywebview's real `parse_file_type` (importorskip'd where the desktop runtime is absent); 42 pass.
- `npm run check` (schema drift, typecheck, lint, vitest, build, bundle size) against a clean checkout of this branch: 2135 pass. `ruff` clean on the touched backend files.
- Manual against the built bundle at the app's real 1440x900 window: dock 760x110 with a 738x36 rail, 26px pills, 28px attach circle, 30px primary; typed a draft and confirmed Send enables, chips ellipsize long model ids inside their fixed boxes, and disabled chips keep their tooltips.
