### PR TITLE
Hold every text token to a published WCAG tier in both themes

### DIFF
--- a/web_ui/src/lib/tokens/gl-vars-dev.css
+++ b/web_ui/src/lib/tokens/gl-vars-dev.css
@@ -51,10 +51,27 @@
  * app is a pure gray, R=G=B - a deliberate "graphite" monochrome design,
  * not colorful branding), inverted per-channel for solid hex tokens and
  * polarity-flipped for alpha-wash tokens, then spot-checked against real
- * WCAG relative-luminance contrast ratios (not raw RGB distance) - one
- * token (--gl-surface-text-muted) needed a manual correction beyond the
- * mechanical inversion to match its dark-mode counterpart's own contrast
- * ratio; every other token is the direct derivation. */
+ * WCAG relative-luminance contrast ratios (not raw RGB distance).
+ *
+ * The text-carrying tokens are NOT the mechanical inversion: each one is
+ * solved so that BOTH themes clear the same WCAG 2.2 tier against the
+ * worst-case (lowest-contrast) surface they are ever painted on, which is
+ * --gl-surface-field in both directions. Two tiers, both straight out of
+ * the spec - nothing bespoke:
+ *
+ *   AAA normal text, 7:1 - text-bright/strong/primary/soft/secondary/label
+ *   AA  normal text, 4.5:1 - the deliberately de-emphasized roles:
+ *                            text-muted, the four semantic-status greys,
+ *                            palette-selection, search-highlight
+ *
+ * (4.5:1 is simultaneously WCAG AA for normal text and AAA for large text,
+ * so the de-emphasized tier is a real published bar, not a local carve-out.
+ * It replaces the old AA-large 3:1 allowance, under which text-muted -
+ * which carries more of this app's text than any token except
+ * text-primary - sat at 3.29:1 against a field surface and read as
+ * washed out in dark mode.)
+ *
+ * token-theme-contrast.test.ts enforces exactly this table. */
 :root {
   --gl-composer-attach-button-background: rgba(255, 255, 255, 0.018);
   --gl-composer-attach-button-border: rgba(150, 150, 150, 0.28);
@@ -135,7 +152,7 @@
   --gl-neutral-button-pressed: #343434;
   --gl-palette-ai-node: #828282;
   --gl-palette-nav-highlight: #949494;
-  --gl-palette-selection: #858585;
+  --gl-palette-selection: #939393;
   --gl-palette-user-node: #838383;
   --gl-radius-lg: 12px;
   --gl-radius-md: 8px;
@@ -144,11 +161,11 @@
   --gl-semantic-conversation-ai-bubble: #323232;
   --gl-semantic-conversation-user-bubble: #696969;
   --gl-semantic-default: #858585;
-  --gl-semantic-search-highlight: #949494;
-  --gl-semantic-status-error: #848484;
-  --gl-semantic-status-info: #828282;
-  --gl-semantic-status-success: #838383;
-  --gl-semantic-status-warning: #919191;
+  --gl-semantic-search-highlight: #a2a2a2;
+  --gl-semantic-status-error: #929292;
+  --gl-semantic-status-info: #909090;
+  --gl-semantic-status-success: #919191;
+  --gl-semantic-status-warning: #9f9f9f;
   --gl-shadow-1: 0 1px 3px rgba(0, 0, 0, 0.40);
   --gl-shadow-2: 0 4px 12px rgba(0, 0, 0, 0.45);
   --gl-shadow-3: 0 8px 28px rgba(0, 0, 0, 0.55);
@@ -170,8 +187,8 @@
   --gl-surface-inset-deep: #121212;
   --gl-surface-node-body: #252525;
   --gl-surface-text-bright: #FFFFFF;
-  --gl-surface-text-label: #A4A4A4;
-  --gl-surface-text-muted: #767676;
+  --gl-surface-text-label: #B4B4B4;
+  --gl-surface-text-muted: #949494;
   --gl-surface-text-primary: #E0E0E0;
   --gl-surface-text-secondary: #BDBDBD;
   --gl-surface-text-soft: #CCCCCC;
@@ -269,7 +286,7 @@
     --gl-neutral-button-pressed: #CBCBCB;
     --gl-palette-ai-node: #7D7D7D;
     --gl-palette-nav-highlight: #6B6B6B;
-    --gl-palette-selection: #7A7A7A;
+    --gl-palette-selection: #595959;
     --gl-palette-user-node: #7C7C7C;
     --gl-radius-lg: 12px;
     --gl-radius-md: 8px;
@@ -278,11 +295,11 @@
     --gl-semantic-conversation-ai-bubble: #CDCDCD;
     --gl-semantic-conversation-user-bubble: #969696;
     --gl-semantic-default: #7A7A7A;
-    --gl-semantic-search-highlight: #6B6B6B;
-    --gl-semantic-status-error: #7B7B7B;
-    --gl-semantic-status-info: #7D7D7D;
-    --gl-semantic-status-success: #7C7C7C;
-    --gl-semantic-status-warning: #6E6E6E;
+    --gl-semantic-search-highlight: #4A4A4A;
+    --gl-semantic-status-error: #5A5A5A;
+    --gl-semantic-status-info: #5C5C5C;
+    --gl-semantic-status-success: #5B5B5B;
+    --gl-semantic-status-warning: #4D4D4D;
     --gl-shadow-1: 0 1px 3px rgba(0, 0, 0, 0.18);
     --gl-shadow-2: 0 4px 12px rgba(0, 0, 0, 0.203);
     --gl-shadow-3: 0 8px 28px rgba(0, 0, 0, 0.248);
@@ -304,8 +321,8 @@
     --gl-surface-inset-deep: #EDEDED;
     --gl-surface-node-body: #DADADA;
     --gl-surface-text-bright: #000000;
-    --gl-surface-text-label: #5B5B5B;
-    --gl-surface-text-muted: #717171;
+    --gl-surface-text-label: #404040;
+    --gl-surface-text-muted: #5A5A5A;
     --gl-surface-text-primary: #1F1F1F;
     --gl-surface-text-secondary: #424242;
     --gl-surface-text-soft: #333333;
@@ -399,7 +416,7 @@
   --gl-neutral-button-pressed: #CBCBCB;
   --gl-palette-ai-node: #7D7D7D;
   --gl-palette-nav-highlight: #6B6B6B;
-  --gl-palette-selection: #7A7A7A;
+  --gl-palette-selection: #595959;
   --gl-palette-user-node: #7C7C7C;
   --gl-radius-lg: 12px;
   --gl-radius-md: 8px;
@@ -408,11 +425,11 @@
   --gl-semantic-conversation-ai-bubble: #CDCDCD;
   --gl-semantic-conversation-user-bubble: #969696;
   --gl-semantic-default: #7A7A7A;
-  --gl-semantic-search-highlight: #6B6B6B;
-  --gl-semantic-status-error: #7B7B7B;
-  --gl-semantic-status-info: #7D7D7D;
-  --gl-semantic-status-success: #7C7C7C;
-  --gl-semantic-status-warning: #6E6E6E;
+  --gl-semantic-search-highlight: #4A4A4A;
+  --gl-semantic-status-error: #5A5A5A;
+  --gl-semantic-status-info: #5C5C5C;
+  --gl-semantic-status-success: #5B5B5B;
+  --gl-semantic-status-warning: #4D4D4D;
   --gl-shadow-1: 0 1px 3px rgba(0, 0, 0, 0.18);
   --gl-shadow-2: 0 4px 12px rgba(0, 0, 0, 0.203);
   --gl-shadow-3: 0 8px 28px rgba(0, 0, 0, 0.248);
@@ -434,8 +451,8 @@
   --gl-surface-inset-deep: #EDEDED;
   --gl-surface-node-body: #DADADA;
   --gl-surface-text-bright: #000000;
-  --gl-surface-text-label: #5B5B5B;
-  --gl-surface-text-muted: #717171;
+  --gl-surface-text-label: #404040;
+  --gl-surface-text-muted: #5A5A5A;
   --gl-surface-text-primary: #1F1F1F;
   --gl-surface-text-secondary: #424242;
   --gl-surface-text-soft: #333333;

--- a/web_ui/src/lib/tokens/token-theme-contrast.test.ts
+++ b/web_ui/src/lib/tokens/token-theme-contrast.test.ts
@@ -139,50 +139,100 @@ function contrastRatio(hexA: string, hexB: string): number {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
+const WCAG_AAA_TEXT = 7.0;
 const WCAG_AA_TEXT = 4.5;
-const WCAG_AA_LARGE_TEXT = 3.0;
 
-// The surface/text pairs that carry real body copy - not every token
-// (borders/shadows/dividers are deliberately low-contrast by design in
-// BOTH themes, see gl-vars-dev.css's own derivation notes; testing those
-// against a text-contrast bar would be testing the wrong thing).
+// Every token that carries text is held to a published WCAG 2.2 tier, and
+// held to it against the WORST-CASE surface it can be painted on rather
+// than only against the window: --gl-surface-field is the lightest dark
+// surface and the darkest light one, so a token that clears the bar there
+// clears it on every other surface in the same theme.
 //
-// text-muted is held to AA-LARGE (3:1), not full AA-normal-text (4.5:1) -
-// not a carve-out invented for this test, but the pre-existing dark
-// palette's own actual ratio: #1E1E1E/#767676 is 3.67:1, already below
-// 4.5:1 before this stage touched anything, consistent with "muted" being
-// a deliberately de-emphasized role (captions/hints, not body copy). The
-// light derivation (#E1E1E1/#717171, 3.73:1) was hand-corrected beyond the
-// mechanical inversion specifically to match this same bar, not to invent
-// a new one.
-const TEXT_SURFACE_PAIRS: Array<[surface: string, text: string, minRatio: number]> = [
-  ["--gl-surface-window", "--gl-surface-text-bright", WCAG_AA_TEXT],
-  ["--gl-surface-window", "--gl-surface-text-strong", WCAG_AA_TEXT],
-  ["--gl-surface-window", "--gl-surface-text-primary", WCAG_AA_TEXT],
-  ["--gl-surface-window", "--gl-surface-text-soft", WCAG_AA_TEXT],
-  ["--gl-surface-window", "--gl-surface-text-secondary", WCAG_AA_TEXT],
-  ["--gl-surface-window", "--gl-surface-text-label", WCAG_AA_TEXT],
-  ["--gl-surface-window", "--gl-surface-text-muted", WCAG_AA_LARGE_TEXT],
-  ["--gl-surface-node-body", "--gl-surface-text-primary", WCAG_AA_TEXT],
-  ["--gl-surface-inset-deep", "--gl-surface-text-primary", WCAG_AA_TEXT],
-  ["--gl-surface-field", "--gl-composer-input-text", WCAG_AA_TEXT],
+//   AAA normal text (7:1)  - the body/heading roles.
+//   AA normal text (4.5:1) - the deliberately de-emphasized roles. 4.5:1 is
+//                            simultaneously AA for normal text and AAA for
+//                            large text, so this is a real published bar,
+//                            not a local carve-out.
+//
+// This replaces an AA-large (3:1) allowance that had applied to
+// --gl-surface-text-muted alone. Muted carries more of this app's text than
+// any token except --gl-surface-text-primary, and at 3.29:1 against a field
+// surface it read as washed out in dark mode; the semantic-status greys were
+// worse still (2.89:1 in light). Borders, shadows and dividers are NOT in
+// this table - they are deliberately low-contrast in both themes, and
+// testing them against a text bar would be testing the wrong thing.
+const TEXT_TOKENS: Array<[textVar: string, minRatio: number]> = [
+  ["--gl-surface-text-bright", WCAG_AAA_TEXT],
+  ["--gl-surface-text-strong", WCAG_AAA_TEXT],
+  ["--gl-surface-text-primary", WCAG_AAA_TEXT],
+  ["--gl-surface-text-soft", WCAG_AAA_TEXT],
+  ["--gl-surface-text-secondary", WCAG_AAA_TEXT],
+  ["--gl-surface-text-label", WCAG_AAA_TEXT],
+  ["--gl-surface-text-muted", WCAG_AA_TEXT],
+  ["--gl-semantic-status-error", WCAG_AA_TEXT],
+  ["--gl-semantic-status-warning", WCAG_AA_TEXT],
+  ["--gl-semantic-status-success", WCAG_AA_TEXT],
+  ["--gl-semantic-status-info", WCAG_AA_TEXT],
+  ["--gl-palette-selection", WCAG_AA_TEXT],
+  ["--gl-semantic-search-highlight", WCAG_AA_TEXT],
+];
+
+// The lowest-contrast surface each theme ever paints text on.
+const WORST_CASE_SURFACE = "--gl-surface-field";
+
+// The remaining surfaces that carry real body copy, checked for the primary
+// body token so a surface can never drift light/dark on its own.
+const BODY_SURFACES = [
+  "--gl-surface-window",
+  "--gl-surface-node-body",
+  "--gl-surface-inset",
+  "--gl-surface-inset-deep",
 ];
 
 describe.each([
   ["dark", darkTokens],
   ["light", explicitLightTokens],
-] as const)("%s theme: text/surface contrast meets its WCAG bar", (themeName, tokens) => {
-  it.each(TEXT_SURFACE_PAIRS)("%s / %s (>= %s:1)", (surfaceVar, textVar, minRatio) => {
-    const surfaceHex = tokens.get(surfaceVar);
-    const textHex = tokens.get(textVar);
-    expect(surfaceHex, `${surfaceVar} missing in ${themeName}`).toBeDefined();
-    expect(textHex, `${textVar} missing in ${themeName}`).toBeDefined();
+] as const)("%s theme: text contrast meets its WCAG bar", (themeName, tokens) => {
+  const surfaceHex = () => {
+    const hex = tokens.get(WORST_CASE_SURFACE);
+    expect(hex, `${WORST_CASE_SURFACE} missing in ${themeName}`).toBeDefined();
+    return hex!;
+  };
 
-    const ratio = contrastRatio(surfaceHex!, textHex!);
+  it.each(TEXT_TOKENS)(
+    `%s on ${WORST_CASE_SURFACE} (>= %s:1)`,
+    (textVar, minRatio) => {
+      const textHex = tokens.get(textVar);
+      expect(textHex, `${textVar} missing in ${themeName}`).toBeDefined();
+
+      const surface = surfaceHex();
+      const ratio = contrastRatio(surface, textHex!);
+      expect(
+        ratio,
+        `${themeName} ${WORST_CASE_SURFACE}(${surface}) / ${textVar}(${textHex}) = ${ratio.toFixed(2)}:1, needs >= ${minRatio}:1`,
+      ).toBeGreaterThanOrEqual(minRatio);
+    },
+  );
+
+  it.each(BODY_SURFACES)("--gl-surface-text-primary on %s (>= 7:1)", (surfaceVar) => {
+    const surface = tokens.get(surfaceVar);
+    const textHex = tokens.get("--gl-surface-text-primary");
+    expect(surface, `${surfaceVar} missing in ${themeName}`).toBeDefined();
+    expect(textHex).toBeDefined();
+
+    const ratio = contrastRatio(surface!, textHex!);
     expect(
       ratio,
-      `${themeName} ${surfaceVar}(${surfaceHex}) / ${textVar}(${textHex}) = ${ratio.toFixed(2)}:1, needs >= ${minRatio}:1`,
-    ).toBeGreaterThanOrEqual(minRatio);
+      `${themeName} ${surfaceVar}(${surface}) / primary(${textHex}) = ${ratio.toFixed(2)}:1`,
+    ).toBeGreaterThanOrEqual(WCAG_AAA_TEXT);
+  });
+
+  it("the composer input's own text clears AAA on its field", () => {
+    const surface = tokens.get("--gl-surface-field");
+    const textHex = tokens.get("--gl-composer-input-text");
+    expect(surface).toBeDefined();
+    expect(textHex).toBeDefined();
+    expect(contrastRatio(surface!, textHex!)).toBeGreaterThanOrEqual(WCAG_AAA_TEXT);
   });
 });
 


### PR DESCRIPTION
## Problem

Dark-mode text read as washed out, and the token system permitted it. Measured against `--gl-surface-field` - the lowest-contrast surface either palette ever paints text on - the de-emphasized tokens sat below the WCAG AA floor for normal text:

| token | dark | light |
| --- | --- | --- |
| `--gl-surface-text-muted` | 3.29:1 | 3.42:1 |
| `--gl-semantic-status-info` | 3.89:1 | 2.89:1 |
| `--gl-semantic-status-success` | 3.94:1 | 2.93:1 |
| `--gl-semantic-status-error` | 3.99:1 | 2.97:1 |
| `--gl-palette-selection` | 4.05:1 | 3.01:1 |
| `--gl-semantic-status-warning` | 4.74:1 | 3.58:1 |
| `--gl-semantic-search-highlight` | 4.92:1 | 3.74:1 |
| `--gl-surface-text-label` | 5.99:1 | 4.76:1 |

`--gl-surface-text-muted` alone backs 154 `color:` declarations in `styles.css` - more of the app's text than any token except `--gl-surface-text-primary` - so its 3.29:1 is what makes the interface as a whole read dim rather than any single element.

The contrast test permitted all of it: it held muted to AA-large (3:1) as a documented allowance, covered no semantic-status token at all, and measured only against `--gl-surface-window` rather than the worst-case surface.

## Change

Two published WCAG 2.2 tiers, each enforced against the worst-case surface in both palettes:

- **AAA normal text, 7:1** - `text-bright`, `text-strong`, `text-primary`, `text-soft`, `text-secondary`, `text-label`
- **AA normal text, 4.5:1** - the deliberately de-emphasized roles: `text-muted`, the four semantic-status greys, `palette-selection`, `search-highlight`

4.5:1 is simultaneously AA for normal text and AAA for large text, so the de-emphasized tier is a real published bar rather than a locally invented one.

Only tokens that missed their tier moved - `text-bright` through `text-secondary` already cleared 7:1 and are untouched. `text-muted` goes `#767676` to `#949494` in dark (3.29:1 to 4.92:1) and `#717171` to `#5A5A5A` in light; `text-label` goes to `#B4B4B4` / `#404040` (7.20:1 / 7.27:1). The status greys are translated as a set so they keep their existing relative offsets: they stay mutually indistinguishable by design, since state in this app is encoded by shape and weight rather than color.

The test now enumerates every text-carrying token against the worst-case surface, additionally checks the primary body token on each remaining body surface, and covers the composer input's own field pairing.

## Test plan

- `token-theme-contrast.test.ts`: 43 pass, covering both palettes.
- Verified the raised bars actually bite: restoring `--gl-surface-text-muted` to `#767676` fails with `dark --gl-surface-field(#272727) / --gl-surface-text-muted(#767676) = 3.29:1, needs >= 4.5:1`, and the file was restored afterwards.
- `npm run check` (schema drift, typecheck, lint, vitest, build, bundle size) against a clean checkout of this branch: 2135 pass.
- Verified live against the built bundle at the app's real 1440x900 window, reading computed values off `:root`: muted `#949494` at 4.92:1, label `#B4B4B4` at 7.20:1, status-error `#929292` at 4.80:1, primary `#E0E0E0` at 11.32:1, all against the resolved `--gl-surface-field`.
