### PR TITLE
Rebuild the node cards on the app's own controls

### DIFF
--- a/web_ui/src/app/canvas/ArtifactNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ArtifactNodeView.test.tsx
@@ -158,12 +158,21 @@ describe("ArtifactNodeView", () => {
     expect(submitButton).toBeEnabled();
   });
 
-  it("the submit button is disabled while pendingRequestId is set, even with non-empty draft", async () => {
+  it("the submit button states that it is busy, and is disabled, while pendingRequestId is set", async () => {
+    // Busy is stated, not merely implied by a greyed-out button still
+    // reading "Generate" - the same posture the sandbox card's "Running…"
+    // takes. Both halves are asserted: the label AND the disabled state.
     const user = userEvent.setup();
     renderArtifactNode({ pendingRequestId: "req-1" });
     const input = screen.getByRole("textbox", { name: "Instruction" });
     await user.type(input, "real text");
-    expect(screen.getByRole("button", { name: "Generate" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Generate" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Generating…" })).toBeDisabled();
+  });
+
+  it("the busy label tracks Refine when the document already has content", () => {
+    renderArtifactNode({ pendingRequestId: "req-1", artifactContent: "# Existing draft" });
+    expect(screen.getByRole("button", { name: "Refining…" })).toBeDisabled();
   });
 
   // -- submit / Enter / Shift+Enter -------------------------------------------

--- a/web_ui/src/app/canvas/ArtifactNodeView.tsx
+++ b/web_ui/src/app/canvas/ArtifactNodeView.tsx
@@ -179,7 +179,18 @@ export const ArtifactNodeView = memo(function ArtifactNodeView({
   }
 
   const hasContent = data.artifactContent.trim().length > 0;
-  const submitLabel = hasContent ? "Refine" : "Generate";
+  const busy = !!data.pendingRequestId;
+  // Busy is stated, not just implied by a greyed-out button. The sandbox
+  // card's Run reads "Running…" while in flight; this one stayed on
+  // "Generate"/"Refine" and merely disabled, which reads as broken rather
+  // than working.
+  const submitLabel = busy
+    ? hasContent
+      ? "Refining…"
+      : "Generating…"
+    : hasContent
+      ? "Refine"
+      : "Generate";
 
   return (
     <NodeShell
@@ -254,12 +265,12 @@ export const ArtifactNodeView = memo(function ArtifactNodeView({
           <button
             type="button"
             className="artifact-node-submit-btn"
-            disabled={!draft.trim() || !!data.pendingRequestId}
+            disabled={!draft.trim() || busy}
             onClick={submit}
           >
             {submitLabel}
           </button>
-          {data.pendingRequestId && (
+          {busy && (
             <button
               type="button"
               className="artifact-node-cancel-btn"

--- a/web_ui/src/app/canvas/GitlinkNodeView.test.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.test.tsx
@@ -398,11 +398,35 @@ describe("GitlinkNodeView", () => {
     const data = renderGitlinkNode({ gitlinkRepoFilePaths: ["src/a.py", "src/b.py"] });
 
     await user.click(screen.getByLabelText("src/a.py"));
-    await user.selectOptions(screen.getByLabelText("Context scope"), "full");
+    // Context scope is a CustomSelect (chrome/CustomSelect.tsx) now, not a
+    // native <select>, so picking an option is a click on the trigger
+    // followed by a click on the portaled option button - the same idiom
+    // SettingsDialog.test.tsx's own chooseCustomOption helper uses.
+    await user.click(screen.getByRole("button", { name: "Context scope" }));
+    await user.click(await screen.findByRole("button", { name: "Full repo" }));
     expect(data.onBuildContext).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "Build Context" }));
     expect(data.onBuildContext).toHaveBeenCalledWith("full", ["src/a.py"]);
+  });
+
+  it("renders file-row checkboxes with the app's drawn checkbox class", () => {
+    // A raw OS checkbox repeated once per file row was the most visible
+    // un-restyled control left on any card.
+    renderGitlinkNode({ gitlinkRepoFilePaths: ["src/a.py", "src/b.py"] });
+    for (const box of screen.getAllByRole("checkbox")) {
+      expect(box).toHaveClass("gl-checkbox");
+    }
+  });
+
+  it("renders the app's own dropdown for Context scope, never a native select", () => {
+    // Every other dropdown in this app (Settings, Builder, Chat Library,
+    // the View popover) is CustomSelect; this card was the last raw
+    // <select>, and an OS dropdown inside a canvas card reads as a foreign
+    // control.
+    renderGitlinkNode();
+    expect(document.querySelector("select")).toBeNull();
+    expect(screen.getByRole("button", { name: "Context scope" })).toBeInTheDocument();
   });
 
   it("Generate Change Set passes the trimmed task-prompt draft directly to onRun", async () => {

--- a/web_ui/src/app/canvas/GitlinkNodeView.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.tsx
@@ -1,5 +1,6 @@
 import type { Node, NodeProps } from "@xyflow/react";
 import { memo, useEffect, useRef, useState } from "react";
+import { CustomSelect, type CustomSelectOption } from "../chrome/CustomSelect";
 import { Dialog, useOverlays } from "../overlays/overlays";
 import { CollapseToggleButton } from "./CollapseToggleButton";
 import type { MenuPosition } from "./menuPosition";
@@ -73,6 +74,11 @@ export interface GitlinkPendingChangeRow {
   reason: string;
   content?: string | null;
 }
+
+const GITLINK_SCOPE_OPTIONS: CustomSelectOption[] = [
+  { id: "selected", label: "Selected files" },
+  { id: "full", label: "Full repo" },
+];
 
 export interface GitlinkNodeData extends Record<string, unknown> {
   gitlinkRepo: string;
@@ -406,6 +412,10 @@ function GitlinkNodeViewImpl({ id, data, selected }: NodeProps<GitlinkFlowNode>)
           {activeTab === "setup" && (
             <div className="gitlink-node-setup-tab" role="tabpanel">
               <div className="gitlink-node-field-row">
+                {/* Labelled, not placeholder-only. Two of this tab's four
+                    fields already carried a real label; these two announced
+                    themselves only until you typed into them. */}
+                <span className="gitlink-node-field-label">Repository</span>
                 <input
                   type="text"
                   className="gitlink-node-input"
@@ -420,6 +430,7 @@ function GitlinkNodeViewImpl({ id, data, selected }: NodeProps<GitlinkFlowNode>)
                   placeholder="owner/repo"
                   aria-label="Repository"
                 />
+                <span className="gitlink-node-field-label">Branch</span>
                 <input
                   type="text"
                   className="gitlink-node-input"
@@ -438,7 +449,16 @@ function GitlinkNodeViewImpl({ id, data, selected }: NodeProps<GitlinkFlowNode>)
                   <button type="button" disabled={busy} onClick={listRepos}>
                     {repoOptionsLoading ? "Loading…" : "List My Repos"}
                   </button>
-                  <button type="button" disabled={busy || !repoDraft.trim()} onClick={loadTree}>
+                  {/* The tab's one primary. Setup had four buttons at equal
+                      weight, so nothing said which one moves you forward -
+                      the same one-primary language the launchers, the plan
+                      card and the sandbox card already use. */}
+                  <button
+                    type="button"
+                    className="gitlink-node-primary-btn"
+                    disabled={busy || !repoDraft.trim()}
+                    onClick={loadTree}
+                  >
                     Load Repo Tree
                   </button>
                 </div>
@@ -456,17 +476,22 @@ function GitlinkNodeViewImpl({ id, data, selected }: NodeProps<GitlinkFlowNode>)
                 )}
               </div>
 
-              <label className="gitlink-node-field-row">
+              {/* The app's own dropdown, not a native <select>. CustomSelect
+                  is what Settings, Builder, Chat Library and the View
+                  popover all render; this card was the last raw <select>
+                  left, and an OS dropdown inside a canvas card reads as a
+                  foreign control. It portals to the body and positions off
+                  getBoundingClientRect, so React Flow's viewport transform
+                  does not affect it. */}
+              <div className="gitlink-node-field-row">
                 <span className="gitlink-node-field-label">Context scope</span>
-                <select
-                  className="gitlink-node-select"
+                <CustomSelect
                   value={scopeMode}
-                  onChange={(event) => setScopeMode(event.target.value)}
-                >
-                  <option value="selected">Selected files</option>
-                  <option value="full">Full repo</option>
-                </select>
-              </label>
+                  options={GITLINK_SCOPE_OPTIONS}
+                  onChange={setScopeMode}
+                  ariaLabel="Context scope"
+                />
+              </div>
 
               <div className="gitlink-node-field-row">
                 <label className="gitlink-node-field-row">
@@ -541,6 +566,7 @@ function GitlinkNodeViewImpl({ id, data, selected }: NodeProps<GitlinkFlowNode>)
                         <label className="gitlink-node-file-row">
                           <input
                             type="checkbox"
+                            className="gl-checkbox"
                             checked={selectedPaths.includes(path)}
                             onChange={() => togglePath(path)}
                           />

--- a/web_ui/src/app/canvas/HtmlNodeView.test.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.test.tsx
@@ -265,19 +265,16 @@ describe("HtmlNodeView", () => {
     );
   });
 
-  it("the Popout button is present, disabled, and wired to nothing observable", async () => {
+  it("renders no Popout control, and never opens a window", () => {
+    // It used to ship as a permanently disabled button explaining itself in
+    // a tooltip. A control the user can never act on is noise on the card;
+    // the reason popout is unbuilt lives in the module doc now. Asserted as
+    // absence rather than deleted outright, so re-adding a dead placeholder
+    // fails here.
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
-    const user = userEvent.setup();
     renderHtmlNode();
 
-    const popout = screen.getByRole("button", { name: "Popout" });
-    expect(popout).toBeDisabled();
-    expect(popout).toHaveAttribute(
-      "title",
-      "Popout view isn't built yet - opening untrusted HTML in a separate window needs a security review first",
-    );
-
-    await user.click(popout); // disabled - fires nothing
+    expect(screen.queryByRole("button", { name: "Popout" })).toBeNull();
     expect(openSpy).not.toHaveBeenCalled();
     openSpy.mockRestore();
   });

--- a/web_ui/src/app/canvas/HtmlNodeView.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.tsx
@@ -28,11 +28,13 @@ import { useLodVisibility } from "./useLodVisibility";
  * see the state split below), collapse/expand (a real per-node toggle, same
  * ChatNode/DocumentNode manual-OR-LOD pattern - unlike CodeNode/ThinkingNode,
  * which have no manual collapse at all), delete. Deliberately, permanently
- * NOT wired (not a temporary stub - see the Popout button below): Popout /
- * standalone window view. Also deliberately not present even as a disabled
- * placeholder: "Open Document View" - there is no clear SPA equivalent for it
- * yet (matches this increment's own scope decision, not carried over from
- * any sibling node's menu).
+ * NOT wired: Popout / standalone window view - opening untrusted HTML in a
+ * separate window needs a security review first. It is not rendered at all,
+ * not even as a disabled button: a control that can never be used is noise
+ * on a card, and the reason for its absence belongs here rather than in a
+ * tooltip nobody can act on. Also deliberately absent: "Open Document View"
+ * - there is no clear SPA equivalent for it yet (matches this increment's
+ * own scope decision, not carried over from any sibling node's menu).
  *
  * Card controls, not a context menu: every sibling node view above uses a
  * right-click dropdown for its actions, but this node's action surface is
@@ -231,14 +233,12 @@ function HtmlNodeViewImpl({ data, selected }: NodeProps<HtmlFlowNode>) {
             <button type="button" className="html-node-header-btn" onClick={data.onToggleCollapse}>
               {data.isCollapsed ? "Expand" : "Collapse"}
             </button>
-            <button
-              type="button"
-              className="html-node-header-btn"
-              disabled
-              title="Popout view isn't built yet - opening untrusted HTML in a separate window needs a security review first"
-            >
-              Popout
-            </button>
+            {/* No Popout control. It shipped as a permanently disabled
+                button with its reason in a tooltip, which is a dead control
+                on a card the user cannot do anything about - the rationale
+                is recorded in this module's own doc instead: opening
+                untrusted HTML in a separate window needs a security review
+                first, and until that happens there is nothing to render. */}
             <button
               type="button"
               className="html-node-header-btn html-node-delete-btn"

--- a/web_ui/src/app/canvas/WebResearchNodeView.test.tsx
+++ b/web_ui/src/app/canvas/WebResearchNodeView.test.tsx
@@ -104,6 +104,24 @@ function makeResult(overrides: Partial<WebResearchResultRow> = {}): WebResearchR
 }
 
 describe("WebResearchNodeView", () => {
+  it("shows an empty state before anything has been researched", () => {
+    // The card used to render a query box above blank space, which never
+    // said what Run would produce.
+    renderWebResearchNode();
+    expect(screen.getByText("No research yet")).toBeInTheDocument();
+  });
+
+  it("does not show the empty state alongside a failure banner", () => {
+    renderWebResearchNode({ researchStage: "failed", researchError: "boom" });
+    expect(screen.queryByText("No research yet")).toBeNull();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("renders the retain-to-knowledge checkbox with the app's drawn checkbox class", () => {
+    renderWebResearchNode();
+    expect(screen.getByRole("checkbox")).toHaveClass("gl-checkbox");
+  });
+
   it("renders the query in the input and the header label", () => {
     renderWebResearchNode({ query: "who won the 2019 world series" });
     expect(screen.getByText("Web Research")).toBeInTheDocument();

--- a/web_ui/src/app/canvas/WebResearchNodeView.tsx
+++ b/web_ui/src/app/canvas/WebResearchNodeView.tsx
@@ -197,6 +197,10 @@ function WebResearchNodeViewImpl({ data, selected }: NodeProps<WebResearchFlowNo
   const isFailed = data.researchStage === "failed";
   const isCancelled = data.researchStage === "cancelled";
   const showProgress = showStepper && data.researchTotal > 0;
+  // Nothing has been asked yet: no result, no failure, no run in flight.
+  // The card previously rendered a query box above blank space, which says
+  // nothing about what Run will produce.
+  const isEmpty = !data.researchResult && !isFailed && !isCancelled && !showStepper;
 
   return (
     <NodeShell
@@ -270,6 +274,7 @@ function WebResearchNodeViewImpl({ data, selected }: NodeProps<WebResearchFlowNo
         <label className="web-research-node-retain nodrag">
           <input
             type="checkbox"
+            className="gl-checkbox"
             checked={data.researchRetainToKnowledge}
             disabled={!!data.pendingRequestId}
             onChange={(event) => data.onSetRetainToKnowledge(event.target.checked)}
@@ -309,6 +314,17 @@ function WebResearchNodeViewImpl({ data, selected }: NodeProps<WebResearchFlowNo
       {isCancelled && (
         <div className="web-research-node-banner web-research-node-banner-cancelled">
           {data.researchError || "Research was cancelled."}
+        </div>
+      )}
+
+      {isEmpty && (
+        // Same empty-state idiom as .library-empty-state (ChatLibraryDialog):
+        // a title naming the state, then one line saying what will fill it.
+        <div className="web-research-node-empty-state">
+          <p className="web-research-node-empty-state-title">No research yet</p>
+          <p className="web-research-node-empty-state-sub">
+            Ask a question and run it to collect cited sources into this node.
+          </p>
         </div>
       )}
 

--- a/web_ui/src/app/chrome/ViewPopover.tsx
+++ b/web_ui/src/app/chrome/ViewPopover.tsx
@@ -220,7 +220,13 @@ function ToggleRow({
           hint into the checkbox's accessible NAME, when the hint is a
           description of the behaviour, not part of what the control is
           called. */}
-      <input type="checkbox" aria-label={label} checked={checked} onChange={(e) => onChange(e.target.checked)} />
+      <input
+        type="checkbox"
+        className="gl-checkbox"
+        aria-label={label}
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
       <span className="view-toggle-text">
         <span className="view-toggle-label">{label}</span>
         <span className="view-toggle-hint">{hint}</span>

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2655,12 +2655,19 @@ body,
   cursor: pointer;
 }
 
-/* A drawn checkbox. These were the last engine-drawn controls in the panel:
-   an OS checkbox sitting beside a custom slider, a custom segmented control
-   and a custom swatch row, with `accent-color` doing what it could. The
-   native input stays - every bit of its keyboard and screen-reader
-   behaviour with it - and only the paint job is replaced. */
-.view-toggle-row input[type="checkbox"] {
+/* A drawn checkbox. These were the last engine-drawn controls in the View
+   panel: an OS checkbox sitting beside a custom slider, a custom segmented
+   control and a custom swatch row, with `accent-color` doing what it could.
+   The native input stays - every bit of its keyboard and screen-reader
+   behaviour with it - and only the paint job is replaced.
+
+   Now a shared class rather than a View-panel-only rule. The canvas node
+   views never got this treatment during the Qt-to-React move, so Web
+   Research's "Save sources to knowledge base" and Gitlink's per-file rows
+   were still rendering raw OS checkboxes inside cards where every other
+   control is drawn - most visible in Gitlink's file list, where the control
+   repeats once per row. One class, one appearance, everywhere. */
+.gl-checkbox {
   appearance: none;
   position: relative;
   flex-shrink: 0;
@@ -2676,18 +2683,19 @@ body,
     border-color var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
-.view-toggle-row:hover input[type="checkbox"]:not(:checked) {
+.gl-checkbox:hover:not(:checked):enabled,
+.view-toggle-row:hover .gl-checkbox:not(:checked):enabled {
   border-color: var(--gl-surface-text-muted);
 }
 
-.view-toggle-row input[type="checkbox"]:checked {
+.gl-checkbox:checked {
   background-color: var(--gl-surface-text-primary);
   border-color: var(--gl-surface-text-primary);
 }
 
 /* The tick, drawn from two borders on a rotated box - no glyph, so it
    cannot pick up a fallback font's own idea of what a checkmark is. */
-.view-toggle-row input[type="checkbox"]:checked::after {
+.gl-checkbox:checked::after {
   content: "";
   position: absolute;
   left: 4px;
@@ -2699,9 +2707,14 @@ body,
   transform: rotate(45deg);
 }
 
-.view-toggle-row input[type="checkbox"]:focus-visible {
+.gl-checkbox:focus-visible {
   outline: 2px solid var(--gl-focus-ring);
   outline-offset: 2px;
+}
+
+.gl-checkbox:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .view-toggle-text {
@@ -6199,6 +6212,15 @@ mark.document-view-search-match-current {
   box-sizing: border-box;
   width: 100%;
   resize: none;
+  /* Native auto-size, the same posture .composer-input and
+     .code-sandbox-node-input already take. Without it a rows=1 textarea
+     with no height of its own stays one line forever: you type a
+     paragraph into this card and can see the last line only. Chromium
+     makes textareas border-box, so these bounds are real pixel bounds. */
+  field-sizing: content;
+  min-height: 34px;
+  max-height: 140px;
+  overflow-y: auto;
   font-family: inherit;
   font-size: 12px;
   line-height: 1.4;
@@ -6423,6 +6445,35 @@ mark.document-view-search-match-current {
   color: var(--gl-surface-text-muted);
 }
 
+/* Empty state, mirroring .library-empty-state's own anatomy (a title naming
+   the state, then one line saying what will fill it) at card scale rather
+   than dialog scale. Without it the card was a query box above blank space,
+   which never told the user what Run would produce. */
+.web-research-node-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 18px 12px;
+  text-align: center;
+  color: var(--gl-surface-text-muted);
+}
+
+.web-research-node-empty-state-title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--gl-surface-text-primary);
+}
+
+.web-research-node-empty-state-sub {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.45;
+  max-width: 260px;
+}
+
 .web-research-node-result {
   display: flex;
   flex-direction: column;
@@ -6513,8 +6564,16 @@ mark.document-view-search-match-current {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-height: 300px;
+  max-height: 430px;
   overflow-y: auto;
+}
+
+/* Same squeeze fix the code_sandbox card documents: a max-height flex
+   column shrinks its children below their content size unless told not to.
+   The instruction row is the one thing on this card that must never be
+   compressed or scrolled out of reach - it is how you use the node at all. */
+.artifact-node-content > * {
+  flex-shrink: 0;
 }
 
 .artifact-node-document {
@@ -6535,9 +6594,14 @@ mark.document-view-search-match-current {
    establish for this pipeline. Only overrides the max-height/overflow-y a
    nested preview pane should never take on its own (the outer
    .artifact-node-content already scrolls). */
+/* The document preview is the unbounded region here (the model returns a
+   whole document every turn), so it is the region that scrolls itself.
+   Leaving it uncapped and letting the card body do the scrolling instead
+   meant a long draft pushed the turn history and the instruction row out
+   of the visible card entirely. */
 .artifact-node-document-content {
-  max-height: none;
-  overflow: visible;
+  max-height: 220px;
+  overflow-y: auto;
 }
 
 /* The turn history - same scrollable-list posture as
@@ -6547,6 +6611,10 @@ mark.document-view-search-match-current {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  /* Bounded for the same reason as the preview above - an N-turn history
+     must not be able to push the instruction row off the card. */
+  max-height: 150px;
+  overflow-y: auto;
 }
 
 /* Per-turn bubble - reuses conversation-node-bubble's own role-modifier
@@ -6578,6 +6646,15 @@ mark.document-view-search-match-current {
   box-sizing: border-box;
   width: 100%;
   resize: none;
+  /* Native auto-size, the same posture .composer-input and
+     .code-sandbox-node-input already take. Without it a rows=1 textarea
+     with no height of its own stays one line forever: you type a
+     paragraph into this card and can see the last line only. Chromium
+     makes textareas border-box, so these bounds are real pixel bounds. */
+  field-sizing: content;
+  min-height: 34px;
+  max-height: 140px;
+  overflow-y: auto;
   font-family: inherit;
   font-size: 12px;
   line-height: 1.4;
@@ -6658,8 +6735,25 @@ mark.document-view-search-match-current {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-height: 340px;
+  /* Budgeted so the whole Setup tab - four labelled fields, its buttons and
+     the bounded repo/file lists - sits inside the card with no outer
+     scrollbar, leaving the file list (the one genuinely unbounded region,
+     capped at 160px below) as the only thing that scrolls. */
+  max-height: 530px;
   overflow-y: auto;
+}
+
+/* THE SQUEEZE, same defect the code_sandbox card had before its rebuild: a
+   max-height flex column shrinks its children below their content size
+   unless told not to, so the Setup tab's fields and rows were compressed
+   until the card both scrolled itself AND scrolled its file list inside -
+   two nested scrollbars on one card, with whichever region straddled the
+   edge cut through the middle. `flex-shrink: 0` is the actual fix; the
+   raised budget above is what lets the common Setup state sit inside the
+   card with no outer scrollbar at all, leaving the file list - the one
+   genuinely unbounded region - as the only thing that scrolls. */
+.gitlink-node-content > * {
+  flex-shrink: 0;
 }
 
 .gitlink-node-tabs {
@@ -6760,6 +6854,25 @@ mark.document-view-search-match-current {
 
 .gitlink-node-inline-row button:hover:enabled {
   background-color: var(--gl-neutral-button-hover);
+}
+
+/* The one filled control in the Setup tab - same treatment
+   .code-sandbox-node-run carries, so "the action that moves you forward"
+   looks the same on every card that has one. */
+.gitlink-node-inline-row button.gitlink-node-primary-btn {
+  color: var(--gl-surface-text-bright);
+  background-color: var(--gl-neutral-button-hover);
+  border-color: var(--gl-neutral-button-border);
+}
+
+.gitlink-node-inline-row button.gitlink-node-primary-btn:hover:enabled {
+  background-color: var(--gl-surface-border-strong);
+}
+
+.gitlink-node-inline-row button.gitlink-node-primary-btn:disabled {
+  color: var(--gl-surface-text-muted);
+  background-color: transparent;
+  border-color: var(--gl-surface-border);
 }
 
 .gitlink-node-inline-row button:disabled {


### PR DESCRIPTION
## Problem

The Qt-to-React refactor modernized the app chrome and left the canvas node views behind. A QA pass over the seven plugin cards - read statically, then measured in the running app at 1440x900 with a fixture holding one node of every kind - found them still rendering controls the rest of the app had already replaced, and two cards unable to size or bound their own content.

- **Gitlink's Context scope was the last native `<select>` in the app.** `CustomSelect` backs every dropdown in Settings, Builder, Chat Library and the View popover, and no node view at all.
- **Raw OS checkboxes** in Web Research's retain-to-knowledge opt-in and Gitlink's per-file rows, while the View panel already ships a drawn checkbox introduced when the team replaced "the last engine-drawn controls" there. Most visible in the file list, where the control repeats once per row.
- **Artifact's and Conversation's instruction inputs were `rows={1}` textareas with no height in CSS at all** - they stayed one line regardless of how much was typed.
- **Artifact bounded its card body and left the document preview unbounded**, so a long draft pushed the turn history and the instruction row out of the visible card.
- **Gitlink's Setup tab scrolled its file list inside an already-scrolling body** - measured `bodyClipped: true` with a nested inner scroller, the same defect the code-sandbox card had before its rebuild: a max-height flex column shrinks its children below their content size unless told not to.
- **Artifact's submit stayed on "Generate" while merely disabled** during a request, where the sandbox card states "Running…".
- **Gitlink labelled two of its four Setup fields** and left the other two placeholder-only, and offered four equal-weight buttons with no primary.
- **Web Research rendered a query box above blank space** with nothing describing what a run produces.
- **The HTML card shipped a permanently disabled "Popout" button** explaining itself in a tooltip.

## Change

Frontend and CSS only - no backend, no wire change, no contract regeneration.

- Gitlink's Context scope uses `CustomSelect`. It portals to the body and positions from `getBoundingClientRect`, so React Flow's viewport transform does not affect it.
- The View panel's drawn checkbox is extracted to a shared `.gl-checkbox` class and adopted by both node-view checkboxes; the View panel itself renders identically.
- Both instruction inputs auto-size natively (`field-sizing: content` with real bounds), the posture `.composer-input` and `.code-sandbox-node-input` already take.
- Artifact's document preview and turn history each scroll themselves, children no longer shrink below their content size, and the instruction row can never be scrolled out of reach.
- Gitlink's Setup tab keeps its children at content size and gets a larger budget, so the nested scrollbars collapse to a single scroll region.
- Artifact's submit reads "Generating…" / "Refining…" while in flight.
- All four Gitlink Setup fields are labelled, and Load Repo Tree is the tab's one primary.
- Web Research renders an empty state before its first run, in `.library-empty-state`'s idiom at card scale.
- The Popout button is removed; the reason popout is unbuilt moves into the module doc, and a test asserts the control's absence so a dead placeholder cannot return.

## Test plan

- `npm run check` (schema drift, typecheck, lint, vitest, build, bundle size) against a clean checkout of this branch: all green.
- New/updated tests: Gitlink renders no native `<select>` and exposes the Context scope trigger; its file-row checkboxes carry `.gl-checkbox`; the scope-mode test drives the real dropdown through the same trigger-then-option idiom `SettingsDialog.test.tsx` uses; Web Research shows the empty state initially, hides it beside a failure banner, and carries the drawn checkbox; Artifact asserts both the busy label and the disabled state, for the Generate and Refine cases; the HTML card asserts Popout's absence and that no window is opened.
- Measured live against the built bundle at 1440x900 with all nine node kinds on the canvas: zero native selects and zero unstyled checkboxes across every card; Artifact's body no longer clips, with its document preview as the single intended scroll region; Gitlink's nested scrolling is gone, leaving one scroll region on a dense card.
