### PR TITLE
Harden the async node kinds: per-node runs, and failures on the node

### DIFF
--- a/backend/agent_dispatch/core.py
+++ b/backend/agent_dispatch/core.py
@@ -267,6 +267,26 @@ class DispatcherCoreOps:
         )
         return resolved.ref if resolved is not None else None
 
+    def is_node_run_live(self, request_id: "str | None") -> bool:
+        """True when `request_id` is a run this registry still holds.
+
+        The per-node busy guard used by gitlink/code_sandbox/artifact/
+        web_research reads node.pending_request_id, but that field outlives
+        a cancelled run: cancelling releases the registry slot immediately
+        while the worker unwinds in its own time. Asking the registry
+        instead means "cancel, then Run again" works the instant the cancel
+        lands, rather than being refused until the dead worker finishes.
+
+        The synchronous claim placeholder counts as live - it is a claim its
+        own caller is about to convert into a real handle."""
+        from backend import agents as agents_module
+
+        if not request_id:
+            return False
+        if request_id == agents_module._NODE_RUN_CLAIM_PLACEHOLDER:
+            return True
+        return self._runs.get(request_id) is not None
+
     def _resolve_branch_system_prompt(self, canvas_document, node_id: str | None) -> str | None:
         """R6.1 port of legacy graphlink_chat_agent.py's
         resolve_branch_system_prompt: given the id of a chat node about to be

--- a/backend/agent_dispatch/research.py
+++ b/backend/agent_dispatch/research.py
@@ -85,8 +85,25 @@ class ResearchDispatchOps:
         already-resolved id, it never resolves one itself (same "caller
         resolves, this method dispatches" split as every other kwarg here)."""
         from backend import agents as agents_module  # deferred: patch-seam + circular-import safety
-        if self._runs.is_busy("web_research"):
-            notifications_state.show("A web research request is already running.", "info")
+        # Per-NODE, for the same reason as start_artifact_reply above: a
+        # canvas whose whole premise is parallel branches should be able to
+        # research two of them at once, and a refusal should name the node
+        # that is actually busy. Same guard gitlink_run/code_sandbox use.
+        # Busy means "this node has a run the registry still holds", not
+        # merely "this node has a request id". Cancelling releases the
+        # registry slot immediately while the cancelled worker unwinds in
+        # its own time, and during that window the node still carries the
+        # dead request's id - reading the field alone would refuse the very
+        # next Run the user clicks after cancelling. The placeholder is the
+        # caller's own synchronous claim (see agents._NODE_RUN_CLAIM_
+        # PLACEHOLDER), which has no handle yet by definition.
+        pending = getattr(node, "pending_request_id", None)
+        if (
+            pending
+            and pending != agents_module._NODE_RUN_CLAIM_PLACEHOLDER
+            and self._runs.get(pending) is not None
+        ):
+            notifications_state.show("Web research is already running for this node.", "info")
             await bus.publish("notification")
             return
 
@@ -97,6 +114,11 @@ class ResearchDispatchOps:
         cancel_token = agents_module.CancellationToken()
         handle = self._runs.claim("web_research", node_id=node_id, on_cancel=cancel_token.cancel)
         request_id = handle.request_id
+        # Stamped HERE, synchronously, not inside _run() below: the busy
+        # guard is this field now, and a value written after the first await
+        # would leave a window in which a second click on the same node sees
+        # an idle node. Same ordering start_gitlink_run already relies on.
+        node.pending_request_id = request_id
         request = agents_module.WebResearchRequest(
             request_id=request_id,
             node_id=node_id,
@@ -118,7 +140,6 @@ class ResearchDispatchOps:
                 fn(*a)
 
         async def _run():
-            node.pending_request_id = request_id
             await bus.publish("scene")
             loop = asyncio.get_running_loop()
             service = agents_module.WebResearchService()
@@ -222,13 +243,6 @@ class ResearchDispatchOps:
         RunRegistry.cancel's own docstring for why kind= is passed."""
         return self._runs.cancel(request_id, kind="web_research")
 
-    def is_web_research_busy(self) -> bool:
-        """Lets callers check the single-slot guard before mutating scene
-        state, so a Run click on a node other than the one already running
-        doesn't reset that node's progress/error fields only to be rejected
-        a moment later by start_web_research's own busy check."""
-        return self._runs.is_busy("web_research")
-
     async def start_artifact_reply(
         self,
         *,
@@ -238,6 +252,7 @@ class ResearchDispatchOps:
         current_artifact: str,
         history: list,
         on_reply,
+        on_failure=None,
     ) -> None:
         """R5.2: the Artifact/Drafter independent-slot counterpart to
         start_image_reply/start_web_research above - NOT a variant of
@@ -276,8 +291,30 @@ class ResearchDispatchOps:
         guard, unlike gitlink_run/code_sandbox's use of the same
         field), so it needs no claim-ordering treatment of its own."""
         from backend import agents as agents_module  # deferred: patch-seam + circular-import safety
-        if self._runs.is_busy("artifact"):
-            notifications_state.show("An artifact request is already running.", "info")
+        # Per-NODE, not per-kind. RunRegistry.is_busy() is kind-scoped and
+        # session-wide (RunHandle's own docstring: node_id is "informational
+        # only ... NEVER consulted"), so one artifact node in flight blocked
+        # every other artifact node on the canvas - and the refusal could not
+        # say which node was holding the slot. gitlink_run/code_sandbox
+        # already guard on node.pending_request_id for exactly this reason
+        # (see AgentDispatcher.__init__'s own comment); this kind now does
+        # too, and the registry claim below stays purely for cancel/task
+        # bookkeeping so cancel()/cancel_all() sweeps are unchanged.
+        # Busy means "this node has a run the registry still holds", not
+        # merely "this node has a request id". Cancelling releases the
+        # registry slot immediately while the cancelled worker unwinds in
+        # its own time, and during that window the node still carries the
+        # dead request's id - reading the field alone would refuse the very
+        # next Run the user clicks after cancelling. The placeholder is the
+        # caller's own synchronous claim (see agents._NODE_RUN_CLAIM_
+        # PLACEHOLDER), which has no handle yet by definition.
+        pending = getattr(node, "pending_request_id", None)
+        if (
+            pending
+            and pending != agents_module._NODE_RUN_CLAIM_PLACEHOLDER
+            and self._runs.get(pending) is not None
+        ):
+            notifications_state.show("Artifact generation is already running for this node.", "info")
             await bus.publish("notification")
             return
 
@@ -288,9 +325,13 @@ class ResearchDispatchOps:
         cancel_event = threading.Event()
         handle = self._runs.claim("artifact", node_id=getattr(node, "id", None), cancel_event=cancel_event)
         request_id = handle.request_id
+        # Synchronous stamp - see start_web_research's own comment above.
+        node.pending_request_id = request_id
+        # Callers that do not record failures on the node (tests, and any
+        # future dispatch surface with no document) keep working unchanged.
+        record_failure = on_failure if on_failure is not None else (lambda _message: None)
 
         async def _run():
-            node.pending_request_id = request_id
             await bus.publish("scene")
             try:
                 new_content, ai_message = await asyncio.wait_for(
@@ -308,11 +349,14 @@ class ResearchDispatchOps:
                     await bus.publish("scene")
             except asyncio.TimeoutError:
                 cancel_event.set()
-                notifications_state.show(
+                message = (
                     "Artifact generation stopped responding before the request completed. "
-                    "Please try again.",
-                    "error",
+                    "Please try again."
                 )
+                # Recorded on the node as well as toasted: the toast says
+                # something failed, the node says WHICH one.
+                record_failure(message)
+                notifications_state.show(message, "error")
                 await bus.publish("notification")
             except Exception as exc:
                 if cancel_event.is_set():
@@ -322,7 +366,9 @@ class ResearchDispatchOps:
                     # noise about work they abandoned.
                     return
                 agents_module.logger.exception("artifact dispatch failed")
-                notifications_state.show(f"Artifact generation failed: {exc}", "error")
+                message = f"Artifact generation failed: {exc}"
+                record_failure(message)
+                notifications_state.show(message, "error")
                 await bus.publish("notification")
             finally:
                 self._runs.release(request_id)

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -197,6 +197,17 @@ _GITLINK_RUN_CLAIM_PLACEHOLDER = "pending"
 # overwrite".
 _CODE_EXEC_RUN_CLAIM_PLACEHOLDER = "pending"
 
+# ADR-002: artifact and web_research moved off the session-wide,
+# kind-scoped RunRegistry.is_busy() guard onto the same per-node guard
+# gitlink/code_sandbox already use, and inherit the same race with it -
+# both of their WS-intent wrappers publish a scene update BEFORE calling
+# the dispatcher, so without a synchronous claim two rapid clicks on ONE
+# node could both pass the guard. Claimed by the wrappers in
+# backend/api/intents_artifact.py and intents_web_research.py before any
+# await; the dispatch methods recognize ONLY this exact value as "already
+# claimed by my own caller, safe to overwrite".
+_NODE_RUN_CLAIM_PLACEHOLDER = "pending"
+
 
 def bootstrap_provider_state(settings_manager: SettingsManager) -> None:
     """Bootstrap api_provider's module-level provider state from persisted

--- a/backend/api/intents_artifact.py
+++ b/backend/api/intents_artifact.py
@@ -61,10 +61,20 @@ def register_artifact_intents(
                 node_ids=[node_id],
             )
 
+        def _on_failure(message):
+            # Recorded as an "agent" command for the same reason _on_reply is:
+            # it is a model-produced outcome, not a direct user action.
+            document.record_command(
+                "failArtifactGeneration", "agent",
+                lambda: document.fail_artifact_generation(node_id, message),
+                node_ids=[node_id],
+            )
+
         await agent_dispatcher.start_artifact_reply(
             bus=bus,
             notifications_state=notifications,
             node=node,
+            on_failure=_on_failure,
             current_artifact=node.state.artifact_content,
             history=full_history,
             on_reply=_on_reply,

--- a/backend/api/intents_web_research.py
+++ b/backend/api/intents_web_research.py
@@ -39,16 +39,33 @@ def register_web_research_intents(
     publish_scene = make_publish_scene(bus)
 
     async def run_web_research(node_id, query_text):
-        if agent_dispatcher.is_web_research_busy():
-            # Checked BEFORE touching document state: start_web_research_run
-            # resets a node's progress/error fields unconditionally, and the
-            # dispatcher only allows one web-research run at a time anyway -
-            # without this early check, clicking Run on a different node
-            # while one is already in flight would silently wipe that node's
-            # prior result/error banner even though no new run actually starts.
-            notifications.show("A web research request is already running.", "info")
+        # Checked BEFORE touching document state: start_web_research_run
+        # resets a node's progress/error fields unconditionally, so a click
+        # that will be refused must not first wipe the banner it is about to
+        # leave standing.
+        #
+        # Per-NODE now, not session-wide. The old check asked "is ANY web
+        # research running", which meant a second research node could not
+        # start while an unrelated one was in flight - on a canvas whose
+        # whole point is parallel branches. Guarding the node's own
+        # pending_request_id is both narrower and exactly what this comment
+        # always wanted: it protects THIS node's state from THIS node's
+        # second click, and says so.
+        busy_node = document.nodes.get(node_id)
+        if busy_node is not None and agent_dispatcher.is_node_run_live(
+            getattr(busy_node, "pending_request_id", None)
+        ):
+            notifications.show("Web research is already running for this node.", "info")
             await bus.publish("notification")
             return None
+        if busy_node is not None:
+            # Claimed synchronously, before the publish below - two rapid
+            # clicks on one node would otherwise both pass the check above.
+            # start_web_research recognizes this exact sentinel as its own
+            # caller's claim. Same mechanism run_code_sandbox already uses.
+            from backend import agents as agents_module
+
+            busy_node.pending_request_id = agents_module._NODE_RUN_CLAIM_PLACEHOLDER
         try:
             node = document.start_web_research_run(node_id, query_text)
         except SceneError:

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -859,7 +859,7 @@ class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
         GET /api/assets/{id} route calls to serve the raw bytes + mime type."""
         return self.image_assets.get(asset_id)
 
-    def add_conversation_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+    def add_conversation_node(self, x: float, y: float, parent_id: str | None) -> SceneNode:
         """R3.25's ConversationNode equivalent of add_document_node/
         add_thinking_node/add_html_node/add_image_node: a real multi-message
         conversation node. Same as document/thinking/html/image (and unlike
@@ -955,7 +955,7 @@ class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
 
     # -- R5.1: web research node ---------------------------------------------
 
-    def add_web_research_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+    def add_web_research_node(self, x: float, y: float, parent_id: str | None) -> SceneNode:
         """The Web Research node's creation primitive - same required-parent
         posture as document/thinking/html/image/conversation nodes (never
         exists unparented). Title is always the fixed literal "Web Research"
@@ -1043,7 +1043,7 @@ class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
 
     # -- R5.2: artifact/drafter node -----------------------------------------
 
-    def add_artifact_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+    def add_artifact_node(self, x: float, y: float, parent_id: str | None) -> SceneNode:
         """The Artifact/Drafter node's creation primitive - same required-
         parent posture as document/thinking/html/image/conversation/
         web_research nodes (never exists unparented). Title is always the
@@ -1076,6 +1076,24 @@ class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
         node.history.append({"role": "user", "content": str(text)})
+        # A new instruction supersedes the previous failure - leaving the
+        # banner up beside an in-flight run would report a stale outcome.
+        node.state.artifact_error = ""
+        return node
+
+    def fail_artifact_generation(self, node_id: str, message: str) -> SceneNode | None:
+        """Record a generation failure ON the node, so the card can say what
+        went wrong instead of leaving a session-wide toast to be matched to
+        one of several artifact nodes by guesswork.
+
+        Returns None for a node that no longer exists rather than raising:
+        this is called from the dispatch task's own except/timeout paths,
+        where the node may well have been deleted mid-flight, and a failure
+        report is not worth turning into a second failure."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            return None
+        node.state.artifact_error = str(message)
         return node
 
     def send_artifact_message(self, node_id: str, text: str) -> SceneNode:
@@ -1101,6 +1119,7 @@ class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
         node.state.artifact_content = str(new_content)
+        node.state.artifact_error = ""
         node.history.append({"role": "assistant", "content": str(ai_message)})
         return node
 
@@ -1114,7 +1133,7 @@ class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
     # from graphlink_plugins.gitlink - same precedent as ArtifactAgent/
     # web_research.domain already being imported there, not here.
 
-    def add_gitlink_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+    def add_gitlink_node(self, x: float, y: float, parent_id: str | None) -> SceneNode:
         """The Gitlink node's creation primitive - same required-parent
         posture as document/thinking/html/image/conversation/web_research/
         artifact nodes (never exists unparented - confirmed against
@@ -1356,7 +1375,7 @@ class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
     # Same import posture as every other plugin-backed kind's domain methods:
     # canvas.py imports NOTHING from graphlink_plugins.code_sandbox.
 
-    def add_code_sandbox_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+    def add_code_sandbox_node(self, x: float, y: float, parent_id: str | None) -> SceneNode:
         """The Virtual Environment Runner node's creation primitive - same
         required-parent posture as every R5 sibling. Title is always the
         fixed literal "Virtual Environment Runner" (matches
@@ -2280,6 +2299,7 @@ class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
                 n.state.research_retain_to_knowledge if isinstance(n.state, WebResearchState) else False
             ),
             "artifactContent": n.state.artifact_content if isinstance(n.state, ArtifactState) else "",
+            "artifactError": n.state.artifact_error if isinstance(n.state, ArtifactState) else "",
             "gitlinkRepo": n.state.gitlink_repo if isinstance(n.state, GitlinkState) else "",
             "gitlinkBranch": n.state.gitlink_branch if isinstance(n.state, GitlinkState) else "",
             "gitlinkScopeMode": (

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -80,6 +80,15 @@ class ArtifactState(NodeState):
     needed."""
 
     artifact_content: str = ""
+    # Why a field at all: an artifact generation that fails used to report
+    # only through a session-wide notification toast, so with two artifact
+    # nodes on the canvas there was no way to tell WHICH one failed. Every
+    # other async node kind already carries its failure on the node itself
+    # (WebResearchState.research_error, and gitlink/code_sandbox's own
+    # in-card banners). Live-wire only, deliberately: research_error is
+    # absent from session_save.py/session_load.py too, so a failure is not
+    # something a reloaded session resurrects.
+    artifact_error: str = ""
 
 
 @dataclass

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -411,6 +411,7 @@ BuiltinActionHandler = Callable[[SceneDocument, PluginRunContext, "str | None"],
 
 def make_simple_child_node_handler(
     *, command_type: str, warning_suffix: str, create: Callable[[SceneDocument, str], SceneNode],
+    create_standalone: "Callable[[SceneDocument, float, float], SceneNode] | None" = None,
 ) -> BuiltinActionHandler:
     """Factory for the one BuiltinActionHandler shape shared, byte-for-byte
     apart from three call-site-specific values, by 6 of the 7 register_
@@ -432,17 +433,38 @@ def make_simple_child_node_handler(
     zero-arg closure and must return the created SceneNode - callers close
     over document.place_child(...)'s own kind string and any extra
     positional args their add_*_node factory needs (e.g. html_renderer's
-    empty initial html_content)."""
+    empty initial html_content).
+
+    'create_standalone' opts a plugin into being creatable with NOTHING
+    selected. Five of the six kinds using this factory never read the
+    parent's content at all - parent_node_id is only a place_child anchor
+    and an edge - so requiring a selection was a positional convenience
+    dressed up as a dependency, and it made the whole picker a dead end on
+    an empty canvas. When it is provided and no valid parent is selected,
+    it is called as create_standalone(document, x, y) with the viewport
+    centre the picker reported (PluginRunContext.spawn_x/spawn_y) and the
+    created node is left unconnected. Omit it and the parent stays
+    genuinely required - html_renderer does, because it really does seed
+    its content from document.nodes[parent_node_id].content."""
 
     def _execute(
         document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
     ) -> "str | None":
         if not parent_node_id or parent_node_id not in document.nodes:
-            run_ctx.notifications.show(
-                f"Please select a valid node to branch from before adding {warning_suffix}.",
-                "warning",
+            if create_standalone is None:
+                run_ctx.notifications.show(
+                    f"Please select a valid node to branch from before adding {warning_suffix}.",
+                    "warning",
+                )
+                return None
+            x = float(run_ctx.spawn_x or 0.0)
+            y = float(run_ctx.spawn_y or 0.0)
+            node, _command = document.record_command(
+                command_type, "user",
+                lambda: create_standalone(document, x, y),
+                node_ids=[],
             )
-            return None
+            return node.id
         node, _command = document.record_command(
             command_type, "user",
             lambda: create(document, parent_node_id),

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -120,10 +120,6 @@ _CATEGORY_META = [
         "description": "Deep thinking and web retrieval for exploring complex questions and grounding decisions.",
     },
     {
-        "name": "Validation & Delivery",
-        "description": "Acceptance reviews, branch comparison, and delivery-focused checks that harden work before release.",
-    },
-    {
         "name": "Build & Execution",
         "description": "Code generation, isolated execution, and rendering tools for turning ideas into working artifacts.",
     },

--- a/backend/tests/test_adr021_dead_paths.py
+++ b/backend/tests/test_adr021_dead_paths.py
@@ -167,7 +167,7 @@ class TestWebResearchRetentionOptIn:
                 seen.update(kwargs)
 
             dispatcher.start_web_research = fake_start
-            dispatcher.is_web_research_busy = lambda: False
+            dispatcher.is_node_run_live = lambda request_id: False
 
             await bus.dispatch_intent("scene", "runWebResearch", [node.id, "why is the sky blue"])
 
@@ -187,7 +187,7 @@ class TestWebResearchRetentionOptIn:
                 seen.update(kwargs)
 
             dispatcher.start_web_research = fake_start
-            dispatcher.is_web_research_busy = lambda: False
+            dispatcher.is_node_run_live = lambda request_id: False
 
             await bus.dispatch_intent("scene", "runWebResearch", [node.id, "a question"])
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -2928,7 +2928,7 @@ def test_run_web_research_intent_publishes_scene_and_calls_start_web_research_wi
         def cancel_web_research(self, request_id):
             return False
 
-        def is_web_research_busy(self):
+        def is_node_run_live(self, request_id):
             return False
 
     async def run():
@@ -3001,7 +3001,7 @@ def test_run_web_research_intent_resolves_the_calling_sessions_workspace_collect
         def cancel_web_research(self, request_id):
             return False
 
-        def is_web_research_busy(self):
+        def is_node_run_live(self, request_id):
             return False
 
     async def run():
@@ -3052,7 +3052,7 @@ def test_run_web_research_never_misreads_a_note_edge_as_the_branch_parent():
         def cancel_web_research(self, request_id):
             return False
 
-        def is_web_research_busy(self):
+        def is_node_run_live(self, request_id):
             return False
 
     async def run():
@@ -3116,7 +3116,7 @@ def test_cancel_web_research_request_intent_calls_agent_dispatcher_cancel_web_re
             self.cancel_calls.append(request_id)
             return True
 
-        def is_web_research_busy(self):
+        def is_node_run_live(self, request_id):
             return False
 
     async def run():
@@ -3176,33 +3176,84 @@ def test_run_web_research_mid_flight_delete_of_the_node_is_a_silent_noop():
     asyncio.run(run())
 
 
-def test_run_web_research_on_a_different_node_while_one_is_busy_does_not_clobber_its_state():
-    # Review-found regression guard: run_web_research used to call
-    # start_web_research_run (which unconditionally resets research_stage/
-    # research_error/progress fields and republishes scene) BEFORE checking
-    # whether AgentDispatcher's single in-flight slot was already busy - so
-    # clicking Run on node B while node A was mid-research would silently wipe
-    # B's existing failure/cancelled banner even though no new run for B ever
-    # actually started. The busy check must happen first.
+def test_run_web_research_on_a_different_node_runs_alongside_one_already_in_flight():
+    # The busy guard is per-NODE, not session-wide. A canvas whose whole
+    # premise is parallel branches must be able to research two of them at
+    # once; the old kind-scoped RunRegistry.is_busy("web_research") let only
+    # one run exist anywhere, so a second research node simply could not
+    # start until the first finished.
     async def run():
         bus, document, recorder, dispatcher = make_bus_with_dispatcher()
         parent = document.add_chat_node(0, 0, "research this please", True)
         node_a = document.add_web_research_node(0, 160, parent.id)
         node_b = document.add_web_research_node(200, 160, parent.id)
 
-        # Give node_b a pre-existing failed state to prove it survives.
-        document.start_web_research_run(node_b.id, "node b's original query")
-        document.fail_web_research_run(node_b.id, cancelled=False, message="node b failed earlier")
-        assert node_b.state.research_stage == "failed"
-        assert node_b.state.research_error == "node b failed earlier"
+        started = threading.Event()
+        release = threading.Event()
+
+        def result_for(query):
+            return ResearchResult(
+                request_id="req",
+                original_query=query,
+                effective_query=query,
+                answer_markdown=f"result for {query}",
+                sources=[],
+                citations=[],
+                warnings=[],
+                provider_snapshot={},
+            )
+
+        def blocking_run(self, request, *, token=None, progress=None):
+            started.set()
+            release.wait(5)
+            return result_for(request.original_query)
+
+        with patch.object(agents_module.WebResearchService, "run", blocking_run):
+            result_a = await bus.dispatch_intent(
+                "scene", "runWebResearch", [node_a.id, "node a's query"]
+            )
+            assert result_a == node_a.id
+            await asyncio.to_thread(started.wait, 5)
+
+            # node_a is in flight. node_b is a DIFFERENT node, so it starts.
+            result_b = await bus.dispatch_intent(
+                "scene", "runWebResearch", [node_b.id, "node b's query"]
+            )
+            assert result_b == node_b.id
+            assert node_b.pending_request_id is not None
+
+            notice = await bus.publish("notification")
+            assert notice["visible"] is False, "a legitimate parallel run must not warn"
+
+            release.set()
+            tasks = [entry["task"] for entry in web_research_slots(dispatcher).values()]
+            for task in tasks:
+                await task
+
+        assert node_a.state.research_stage == "completed"
+        assert node_b.state.research_stage == "completed"
+
+    asyncio.run(run())
+
+
+def test_cancelling_a_web_research_run_frees_the_node_for_an_immediate_rerun():
+    # The per-node guard reads node.pending_request_id, but that field
+    # outlives a CANCELLED run: cancelling releases the registry slot at
+    # once while the worker unwinds in its own time. Guarding on the field
+    # alone would refuse the very next Run the user clicks after cancelling,
+    # so the guard asks the registry whether the request is still live.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_chat_node(0, 0, "research this please", True)
+        node = document.add_web_research_node(0, 160, parent.id)
 
         started = threading.Event()
         release = threading.Event()
         fake_result = ResearchResult(
-            request_id="req-a",
-            original_query="node a's query",
-            effective_query="node a's query",
-            answer_markdown="node a's result",
+            request_id="req",
+            original_query="q",
+            effective_query="q",
+            answer_markdown="done",
             sources=[],
             citations=[],
             warnings=[],
@@ -3215,34 +3266,79 @@ def test_run_web_research_on_a_different_node_while_one_is_busy_does_not_clobber
             return fake_result
 
         with patch.object(agents_module.WebResearchService, "run", blocking_run):
-            result_a = await bus.dispatch_intent(
-                "scene", "runWebResearch", [node_a.id, "node a's query"]
+            assert await bus.dispatch_intent("scene", "runWebResearch", [node.id, "q"]) == node.id
+            await asyncio.to_thread(started.wait, 5)
+            first_request_id = node.pending_request_id
+            assert first_request_id is not None
+
+            # Cancel frees the slot immediately; the worker is still held.
+            assert dispatcher.cancel_web_research(first_request_id) is True
+            assert node.pending_request_id == first_request_id, (
+                "the stale id is still on the node - that is exactly the trap"
             )
-            assert result_a == node_a.id
+
+            second = await bus.dispatch_intent("scene", "runWebResearch", [node.id, "q2"])
+            assert second == node.id, "a cancelled run must not block the next one"
+
+            release.set()
+            for entry in list(web_research_slots(dispatcher).values()):
+                await entry["task"]
+
+    asyncio.run(run())
+
+
+def test_run_web_research_twice_on_the_SAME_node_is_bounced_without_clobbering_it():
+    # The guarantee the old session-wide check was really protecting, kept
+    # and made precise: run_web_research calls start_web_research_run, which
+    # unconditionally resets stage/error/progress, so a click that will be
+    # refused must not first wipe the banner it is about to leave standing.
+    # Now the refusal is about THIS node, and says so.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_chat_node(0, 0, "research this please", True)
+        node = document.add_web_research_node(0, 160, parent.id)
+
+        started = threading.Event()
+        release = threading.Event()
+        fake_result = ResearchResult(
+            request_id="req-a",
+            original_query="the first query",
+            effective_query="the first query",
+            answer_markdown="the first result",
+            sources=[],
+            citations=[],
+            warnings=[],
+            provider_snapshot={},
+        )
+
+        def blocking_run(self, request, *, token=None, progress=None):
+            started.set()
+            release.wait(5)
+            return fake_result
+
+        with patch.object(agents_module.WebResearchService, "run", blocking_run):
+            assert await bus.dispatch_intent(
+                "scene", "runWebResearch", [node.id, "the first query"]
+            ) == node.id
             await asyncio.to_thread(started.wait, 5)
 
-            # node_a is now in flight (the single web-research slot is busy).
-            # Clicking Run on node_b must be rejected up front, WITHOUT
-            # touching node_b's stage/error/content at all.
-            result_b = await bus.dispatch_intent(
-                "scene", "runWebResearch", [node_b.id, "a brand new query for b"]
+            content_before = node.content
+            second = await bus.dispatch_intent(
+                "scene", "runWebResearch", [node.id, "a brand new query"]
             )
-            assert result_b is None
-            assert node_b.state.research_stage == "failed", "node_b's terminal state must survive the bounce"
-            assert node_b.state.research_error == "node b failed earlier"
-            assert node_b.content == "node b's original query", "node_b's content must not be overwritten"
+            assert second is None
+            assert node.content == content_before, "the bounced click must not overwrite the query"
 
             notice = await bus.publish("notification")
             assert notice["visible"] is True
             assert notice["msgType"] == "info"
-            assert notice["message"] == "A web research request is already running."
+            assert notice["message"] == "Web research is already running for this node."
 
             release.set()
             entry = next(iter(web_research_slots(dispatcher).values()))
             await entry["task"]
 
-        assert node_a.state.research_stage == "completed"
-        assert node_a.state.research_result["answerMarkdown"] == "node a's result"
+        assert node.state.research_stage == "completed"
 
     asyncio.run(run())
 
@@ -3259,6 +3355,52 @@ def test_add_artifact_node_creates_a_real_artifact_kind_node():
     assert node.state.artifact_content == ""
     assert node.history == []
     assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_fail_artifact_generation_records_the_message_on_the_node():
+    # A failed generation used to report only through a session-wide
+    # notification toast, so with two artifact nodes there was no way to
+    # tell which one failed. Every other async node kind carries its
+    # failure on the node itself.
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_artifact_node(0, 0, parent.id)
+
+    returned = doc.fail_artifact_generation(node.id, "provider exploded")
+
+    assert returned is node
+    assert node.state.artifact_error == "provider exploded"
+
+
+def test_fail_artifact_generation_on_a_deleted_node_is_a_no_op_not_a_raise():
+    # Called from the dispatch task's own except/timeout paths, where the
+    # node may well have been deleted mid-flight - reporting a failure is
+    # not worth turning into a second failure.
+    doc = SceneDocument()
+    assert doc.fail_artifact_generation("ghost-node", "boom") is None
+
+
+def test_a_new_instruction_clears_the_previous_artifact_failure():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_artifact_node(0, 0, parent.id)
+    doc.fail_artifact_generation(node.id, "provider exploded")
+
+    doc.send_artifact_message(node.id, "try again please")
+
+    assert node.state.artifact_error == "", "a stale banner must not sit beside an in-flight run"
+
+
+def test_a_landed_generation_clears_the_previous_artifact_failure():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_artifact_node(0, 0, parent.id)
+    doc.fail_artifact_generation(node.id, "provider exploded")
+
+    doc.complete_artifact_generation(node.id, "# Draft", "done")
+
+    assert node.state.artifact_error == ""
+    assert node.state.artifact_content == "# Draft"
 
 
 def test_append_artifact_user_message_appends_a_user_turn():

--- a/backend/tests/test_dispatch_claim_ordering.py
+++ b/backend/tests/test_dispatch_claim_ordering.py
@@ -45,9 +45,21 @@ DISPATCHER_SOURCES = tuple(
 )
 
 # (method_name, busy-check kind literal used only for the failure message)
+# Kinds whose busy guard is the session-wide RunRegistry.is_busy(kind).
 MIGRATED_METHODS = [
     ("_dispatch", "chat"),
     ("start_image_reply", "image"),
+]
+
+# Kinds whose busy guard is the PER-NODE node.pending_request_id, the shape
+# gitlink_run/code_sandbox established. The ordering property under test is
+# identical - no await may separate the guard from the claim - but the guard
+# is a pending_request_id comparison rather than an is_busy() call, so it is
+# located differently. artifact and web_research moved onto this shape so two
+# different nodes of the same kind can run at once; that move is exactly what
+# makes the ordering load-bearing for them, since the field is now the gate
+# rather than UI bookkeeping.
+PER_NODE_GUARD_METHODS = [
     ("start_artifact_reply", "artifact"),
     ("start_web_research", "web_research"),
 ]
@@ -87,7 +99,23 @@ def _awaits_reaching_claim(statements):
     return offenders
 
 
-def _assert_no_await_between_busy_check_and_claim(method_name: str, kind: str) -> None:
+def _mentions_pending_request_id(node) -> bool:
+    """True when an `if` test reads node.pending_request_id, in either the
+    direct-attribute form or the getattr(node, "pending_request_id", None)
+    form the dispatch methods use for duck-typed nodes."""
+    for n in ast.walk(node):
+        if isinstance(n, ast.Attribute) and n.attr == "pending_request_id":
+            return True
+        if isinstance(n, ast.Constant) and n.value == "pending_request_id":
+            return True
+        if isinstance(n, ast.Name) and n.id == "pending":
+            return True
+    return False
+
+
+def _assert_no_await_between_busy_check_and_claim(
+    method_name: str, kind: str, *, per_node: bool = False
+) -> None:
     method = _find_method(method_name)
     body = method.body
 
@@ -95,10 +123,21 @@ def _assert_no_await_between_busy_check_and_claim(method_name: str, kind: str) -
         (i for i, stmt in enumerate(body) if isinstance(stmt, ast.If) and _statement_calls(stmt.test, "is_busy")),
         None,
     )
+    if busy_check_index is None and per_node:
+        busy_check_index = next(
+            (
+                i
+                for i, stmt in enumerate(body)
+                if isinstance(stmt, ast.If) and _mentions_pending_request_id(stmt.test)
+            ),
+            None,
+        )
     claim_index = next((i for i, stmt in enumerate(body) if _statement_calls(stmt, "claim")), None)
 
     assert busy_check_index is not None, (
-        f"no `if ...is_busy(...):` guard found in AgentDispatcher.{method_name} - did the guard move?"
+        f"no busy guard found in AgentDispatcher.{method_name} - did the guard move? "
+        "Expected either an `if ...is_busy(...):` check or, for a per-node kind, an "
+        "`if ...pending_request_id...:` check."
     )
     assert claim_index is not None, f"no `...claim(...)` call found in AgentDispatcher.{method_name} - did the claim move?"
     assert busy_check_index < claim_index, "the busy check must precede the claim, not follow it"
@@ -125,3 +164,8 @@ def _assert_no_await_between_busy_check_and_claim(method_name: str, kind: str) -
 def test_no_await_between_busy_check_and_registry_claim():
     for method_name, kind in MIGRATED_METHODS:
         _assert_no_await_between_busy_check_and_claim(method_name, kind)
+
+
+def test_no_await_between_per_node_busy_check_and_registry_claim():
+    for method_name, kind in PER_NODE_GUARD_METHODS:
+        _assert_no_await_between_busy_check_and_claim(method_name, kind, per_node=True)

--- a/backend/tests/test_plugin_builtin_migration.py
+++ b/backend/tests/test_plugin_builtin_migration.py
@@ -142,8 +142,20 @@ def test_builtin_picker_entry_pinned_in_categories_payload(
     assert plugin_entry["description"] == description
 
 
-@pytest.mark.parametrize(_CASE_FIELDS, _BUILTIN_CASES)
-def test_builtin_requires_a_selected_parent_with_the_exact_warning(
+# Only HTML Renderer genuinely needs a parent: its factory seeds the new
+# node's content from document.nodes[parent_node_id].content. The other five
+# never read the parent at all - it was a place_child anchor and an edge -
+# so requiring a selection made the picker a dead end on an empty canvas.
+_PARENT_REQUIRED_IDS = {"html_renderer"}
+_PARENT_REQUIRED_CASES = [c for c in _BUILTIN_CASES if c.id in _PARENT_REQUIRED_IDS]
+_PARENTLESS_CASES = [c for c in _BUILTIN_CASES if c.id not in _PARENT_REQUIRED_IDS]
+
+assert _PARENT_REQUIRED_CASES, "html_renderer case went missing from _BUILTIN_CASES"
+assert len(_PARENTLESS_CASES) == 5, "expected exactly five parentless built-ins"
+
+
+@pytest.mark.parametrize(_CASE_FIELDS, _PARENT_REQUIRED_CASES)
+def test_parent_requiring_builtin_still_refuses_without_a_selection(
     picker_name, description, category, command_type, expected_kind, warning_text, expected_title,
 ):
     bus, notifications, canvas_document = _make_bus()
@@ -157,8 +169,8 @@ def test_builtin_requires_a_selected_parent_with_the_exact_warning(
     assert not any(n.kind == expected_kind for n in canvas_document.nodes.values())
 
 
-@pytest.mark.parametrize(_CASE_FIELDS, _BUILTIN_CASES)
-def test_builtin_rejects_an_unknown_parent_id_with_the_exact_warning(
+@pytest.mark.parametrize(_CASE_FIELDS, _PARENT_REQUIRED_CASES)
+def test_parent_requiring_builtin_still_rejects_an_unknown_parent_id(
     picker_name, description, category, command_type, expected_kind, warning_text, expected_title,
 ):
     bus, notifications, canvas_document = _make_bus()
@@ -168,10 +180,44 @@ def test_builtin_rejects_an_unknown_parent_id_with_the_exact_warning(
     )
 
     assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
     assert notifications.message == warning_text
     assert not any(n.kind == expected_kind for n in canvas_document.nodes.values())
+
+
+@pytest.mark.parametrize(_CASE_FIELDS, _PARENTLESS_CASES)
+def test_parentless_builtin_creates_an_unconnected_node_at_the_reported_spawn_point(
+    picker_name, description, category, command_type, expected_kind, warning_text, expected_title,
+):
+    bus, notifications, canvas_document = _make_bus()
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", [picker_name, None, 240.0, -80.0])
+    )
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == expected_kind
+    assert (node.x, node.y) == (240.0, -80.0)
+    assert not any(e.target == node.id for e in canvas_document.edges.values())
+    assert notifications.visible is False, "creating on an empty canvas is not a deferral"
+    assert canvas_document.command_log[-1].command_type == command_type
+
+
+@pytest.mark.parametrize(_CASE_FIELDS, _PARENTLESS_CASES)
+def test_parentless_builtin_treats_a_stale_selection_as_no_selection(
+    picker_name, description, category, command_type, expected_kind, warning_text, expected_title,
+):
+    # A deleted selection is "nothing is selected", not an error worth
+    # blocking on.
+    bus, notifications, canvas_document = _make_bus()
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", [picker_name, "ghost-node-id", 0.0, 0.0])
+    )
+
+    assert result is not None
+    assert canvas_document.nodes[result].kind == expected_kind
+    assert notifications.visible is False
 
 
 @pytest.mark.parametrize(_CASE_FIELDS, _BUILTIN_CASES)

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -104,6 +104,38 @@ def test_get_plugin_categories_appends_more_plugins_only_if_uncategorized():
     assert "More Plugins" not in [category["name"] for category in grouped_empty]
 
 
+def test_only_html_renderer_still_demands_a_selected_parent():
+    """The picker is not a dead end on an empty canvas.
+
+    Five of the six built-ins using make_simple_child_node_handler never
+    read the parent's content - it was a place_child anchor and an edge -
+    so they create standalone at the reported spawn point. HTML Renderer is
+    the real exception: its factory seeds the new node's content FROM
+    document.nodes[parent_node_id].content.
+
+    Per-builtin name/category/command_type/undo behavior is pinned
+    exhaustively in test_plugin_builtin_migration.py's parametrized suite;
+    this asserts the split itself, once, at the dispatch layer.
+    """
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    created = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Gitlink", None, 12.0, 34.0])
+    )
+    assert created is not None
+    assert canvas_document.nodes[created].kind == "gitlink"
+    assert notifications.visible is False
+
+    refused = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["HTML Renderer", None, 0.0, 0.0])
+    )
+    assert refused is None
+    assert notifications.visible is True
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding an HTML Renderer node."
+    )
+
+
 def test_no_demo_plugin_ships_in_the_picker():
     """The shipped root is exactly the seven first-party plugins.
 
@@ -224,36 +256,6 @@ def _make_plugins_bus():
     return bus, notifications, canvas_document
 
 
-def test_execute_plugin_web_research_with_no_parent_shows_the_exact_warning():
-    bus, notifications, canvas_document = _make_plugins_bus()
-
-    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Web Research"]))
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
-    assert notifications.message == (
-        "Please select a valid node to branch from before adding a Web Node."
-    )
-    assert not any(n.kind == "web_research" for n in canvas_document.nodes.values())
-
-
-def test_execute_plugin_web_research_with_unknown_parent_shows_the_same_warning():
-    bus, notifications, canvas_document = _make_plugins_bus()
-
-    result = asyncio.run(
-        bus.dispatch_intent("app-plugins", "executePlugin", ["Web Research", "ghost-node-id"])
-    )
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
-    assert notifications.message == (
-        "Please select a valid node to branch from before adding a Web Node."
-    )
-    assert not any(n.kind == "web_research" for n in canvas_document.nodes.values())
-
-
 def test_execute_plugin_web_research_with_a_valid_parent_creates_a_real_node_and_publishes_scene():
     bus, notifications, canvas_document = _make_plugins_bus()
     parent = canvas_document.add_node(10, 20, "parent")
@@ -287,36 +289,6 @@ def test_execute_plugin_web_research_with_a_valid_parent_creates_a_real_node_and
 
 
 # -- R5.2: "Artifact / Drafter" - the second real node-creation plugin ------
-
-
-def test_execute_plugin_artifact_drafter_requires_a_selected_parent():
-    bus, notifications, canvas_document = _make_plugins_bus()
-
-    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Artifact / Drafter"]))
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
-    assert notifications.message == (
-        "Please select a valid node to branch from before adding an Artifact node."
-    )
-    assert not any(n.kind == "artifact" for n in canvas_document.nodes.values())
-
-
-def test_execute_plugin_artifact_drafter_rejects_unknown_parent_id():
-    bus, notifications, canvas_document = _make_plugins_bus()
-
-    result = asyncio.run(
-        bus.dispatch_intent("app-plugins", "executePlugin", ["Artifact / Drafter", "ghost-node-id"])
-    )
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
-    assert notifications.message == (
-        "Please select a valid node to branch from before adding an Artifact node."
-    )
-    assert not any(n.kind == "artifact" for n in canvas_document.nodes.values())
 
 
 def test_execute_plugin_artifact_drafter_creates_a_real_artifact_node():
@@ -354,36 +326,6 @@ def test_execute_plugin_artifact_drafter_creates_a_real_artifact_node():
 # -- R5.3: "Gitlink" - the third real node-creation plugin -------------------
 
 
-def test_execute_plugin_gitlink_requires_parent():
-    bus, notifications, canvas_document = _make_plugins_bus()
-
-    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Gitlink"]))
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
-    assert notifications.message == (
-        "Please select a valid node to branch from before adding a Gitlink node."
-    )
-    assert not any(n.kind == "gitlink" for n in canvas_document.nodes.values())
-
-
-def test_execute_plugin_gitlink_rejects_unknown_parent_id():
-    bus, notifications, canvas_document = _make_plugins_bus()
-
-    result = asyncio.run(
-        bus.dispatch_intent("app-plugins", "executePlugin", ["Gitlink", "ghost-node-id"])
-    )
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
-    assert notifications.message == (
-        "Please select a valid node to branch from before adding a Gitlink node."
-    )
-    assert not any(n.kind == "gitlink" for n in canvas_document.nodes.values())
-
-
 def test_execute_plugin_gitlink_creates_node():
     bus, notifications, canvas_document = _make_plugins_bus()
     parent = canvas_document.add_node(10, 20, "parent")
@@ -415,33 +357,6 @@ def test_execute_plugin_gitlink_creates_node():
 
 
 # -- R5.4: "Execution Sandbox" - the fifth real node-creation plugin ----------
-
-
-def test_execute_plugin_execution_sandbox_requires_parent():
-    bus, notifications, canvas_document = _make_plugins_bus()
-
-    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Virtual Environment Runner"]))
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
-    assert notifications.message == (
-        "Please select a valid node to branch from before adding a Virtual Environment Runner node."
-    )
-    assert not any(n.kind == "code_sandbox" for n in canvas_document.nodes.values())
-
-
-def test_execute_plugin_execution_sandbox_rejects_unknown_parent_id():
-    bus, notifications, canvas_document = _make_plugins_bus()
-
-    result = asyncio.run(
-        bus.dispatch_intent("app-plugins", "executePlugin", ["Virtual Environment Runner", "ghost-node-id"])
-    )
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
-    assert not any(n.kind == "code_sandbox" for n in canvas_document.nodes.values())
 
 
 def test_execute_plugin_execution_sandbox_creates_a_real_code_sandbox_node():
@@ -638,33 +553,6 @@ def test_execute_plugin_system_prompt_reuses_an_existing_note_instead_of_creatin
 # with zero UI-reachable creation path - execute_plugin had no branch for
 # it at all, silently falling through to the generic deferred notice despite
 # the node itself being fully functional.
-
-
-def test_execute_plugin_conversation_node_requires_parent():
-    bus, notifications, canvas_document = _make_plugins_bus()
-
-    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Conversation Node"]))
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
-    assert notifications.message == (
-        "Please select a valid node to branch from before adding a Conversation Node."
-    )
-    assert not any(n.kind == "conversation" for n in canvas_document.nodes.values())
-
-
-def test_execute_plugin_conversation_node_rejects_unknown_parent_id():
-    bus, notifications, canvas_document = _make_plugins_bus()
-
-    result = asyncio.run(
-        bus.dispatch_intent("app-plugins", "executePlugin", ["Conversation Node", "ghost-node-id"])
-    )
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "warning"
-    assert not any(n.kind == "conversation" for n in canvas_document.nodes.values())
 
 
 def test_execute_plugin_conversation_node_creates_a_real_conversation_node():

--- a/contracts/graphlink_scene_payload.py
+++ b/contracts/graphlink_scene_payload.py
@@ -440,6 +440,12 @@ class SceneNodeRow:
     # diff/patch). Populated for kind=="artifact" rows, defaulted (empty
     # string) for every other kind.
     artifactContent: str = ""
+    # The Artifact node's last failure, carried on the node rather than left
+    # to a session-wide notification toast - with two artifact nodes on the
+    # canvas a toast cannot say which one failed. Live-wire only, matching
+    # researchError: neither appears in session_save.py/session_load.py, so
+    # a reloaded session does not resurrect a stale failure.
+    artifactError: str = ""
     # R5.3: the Gitlink node's real persisted shape - populated for
     # kind=="gitlink" rows, defaulted for every other kind. gitlinkContextXml
     # is DELIBERATELY NOT one of these fields - see this module's own

--- a/plugins/artifact/plugin.py
+++ b/plugins/artifact/plugin.py
@@ -19,6 +19,9 @@ _execute = make_simple_child_node_handler(
     create=lambda document, parent_node_id: document.add_artifact_node(
         *document.place_child(parent_node_id, "artifact"), parent_node_id
     ),
+    # Creatable with nothing selected: this kind never reads the parent's
+    # content, so the parent was only ever a place_child anchor and an edge.
+    create_standalone=lambda document, x, y: document.add_artifact_node(x, y, None),
 )
 
 
@@ -31,4 +34,5 @@ def register(host: HostContext) -> None:
         ),
         category="Workflow & Drafting",
         handler=_execute,
+        requires_parent=False,
     )

--- a/plugins/code_sandbox/plugin.py
+++ b/plugins/code_sandbox/plugin.py
@@ -20,6 +20,9 @@ _execute = make_simple_child_node_handler(
     create=lambda document, parent_node_id: document.add_code_sandbox_node(
         *document.place_child(parent_node_id, "code_sandbox"), parent_node_id
     ),
+    # Creatable with nothing selected: this kind never reads the parent's
+    # content, so the parent was only ever a place_child anchor and an edge.
+    create_standalone=lambda document, x, y: document.add_code_sandbox_node(x, y, None),
 )
 
 
@@ -33,4 +36,5 @@ def register(host: HostContext) -> None:
         ),
         category="Build & Execution",
         handler=_execute,
+        requires_parent=False,
     )

--- a/plugins/conversation_node/plugin.py
+++ b/plugins/conversation_node/plugin.py
@@ -19,6 +19,9 @@ _execute = make_simple_child_node_handler(
     create=lambda document, parent_node_id: document.add_conversation_node(
         *document.place_child(parent_node_id, "conversation"), parent_node_id
     ),
+    # Creatable with nothing selected: this kind never reads the parent's
+    # content, so the parent was only ever a place_child anchor and an edge.
+    create_standalone=lambda document, x, y: document.add_conversation_node(x, y, None),
 )
 
 
@@ -28,4 +31,5 @@ def register(host: HostContext) -> None:
         description="Adds a node for a self-contained, linear chat conversation.",
         category="Branch Foundations",
         handler=_execute,
+        requires_parent=False,
     )

--- a/plugins/gitlink/plugin.py
+++ b/plugins/gitlink/plugin.py
@@ -19,6 +19,9 @@ _execute = make_simple_child_node_handler(
     create=lambda document, parent_node_id: document.add_gitlink_node(
         *document.place_child(parent_node_id, "gitlink"), parent_node_id
     ),
+    # Creatable with nothing selected: this kind never reads the parent's
+    # content, so the parent was only ever a place_child anchor and an edge.
+    create_standalone=lambda document, x, y: document.add_gitlink_node(x, y, None),
 )
 
 
@@ -31,4 +34,5 @@ def register(host: HostContext) -> None:
         ),
         category="Build & Execution",
         handler=_execute,
+        requires_parent=False,
     )

--- a/plugins/web_research/plugin.py
+++ b/plugins/web_research/plugin.py
@@ -25,6 +25,9 @@ _execute = make_simple_child_node_handler(
     create=lambda document, parent_node_id: document.add_web_research_node(
         *document.place_child(parent_node_id, "web_research"), parent_node_id
     ),
+    # Creatable with nothing selected: this kind never reads the parent's
+    # content, so the parent was only ever a place_child anchor and an edge.
+    create_standalone=lambda document, x, y: document.add_web_research_node(x, y, None),
 )
 
 
@@ -37,4 +40,5 @@ def register(host: HostContext) -> None:
         ),
         category="Reasoning & Research",
         handler=_execute,
+        requires_parent=False,
     )

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -325,7 +325,7 @@ def test_scene_node_core_field_count():
 # (one flat dict literal, no per-kind branching), so one representative node
 # is sufficient; the point is the KEY SET, not per-kind values.
 _EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
-    "artifactContent", "attachmentKind", "branchStatus", "byteSize",
+    "artifactContent", "artifactError", "attachmentKind", "branchStatus", "byteSize",
     "chartAspectLocked", "chartData",
     "chartError", "chartHeight", "chartSourceNodeId", "chartType", "chartWidth",
     "chatScrollValue", "code", "codeSandboxAnalysis",
@@ -412,6 +412,7 @@ _EXPECTED_NON_OWNING_KIND_WIRE_DEFAULTS = {
     "imageAssetId": "",
     "htmlSplitterState": None,
     "artifactContent": "",
+    "artifactError": "",
     "code": "",
     "language": "",
     "isSystemPrompt": False,

--- a/web_ui/src/app/canvas/ArtifactNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ArtifactNodeView.test.tsx
@@ -12,6 +12,7 @@ import { ArtifactNodeView, artifactNodePropsAreEqual, type ArtifactFlowNode } fr
 function baseData(overrides: Partial<ArtifactFlowNode["data"]> = {}): ArtifactFlowNode["data"] {
   return {
     artifactContent: "",
+    artifactError: "",
     history: [],
     isCollapsed: false,
     pendingRequestId: null,
@@ -124,6 +125,22 @@ describe("ArtifactNodeView", () => {
   it("stays expanded above the LOD threshold when isCollapsed is false", () => {
     renderArtifactNodeAtZoom(1, { isCollapsed: false });
     expect(screen.getByRole("textbox", { name: "Instruction" })).toBeInTheDocument();
+  });
+
+  // -- failure banner ---------------------------------------------------------
+
+  it("renders the failure on the card, not just as a session-wide toast", () => {
+    // With two artifact nodes on a canvas, a toast cannot say which one
+    // failed. Every other async node kind already carries its failure on
+    // the node itself.
+    renderArtifactNode({ artifactError: "Artifact generation failed: provider exploded" });
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent("Artifact generation failed: provider exploded");
+  });
+
+  it("renders no failure banner when there is no error", () => {
+    renderArtifactNode({ artifactError: "" });
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   // -- submit label + disabled state ------------------------------------------

--- a/web_ui/src/app/canvas/ArtifactNodeView.tsx
+++ b/web_ui/src/app/canvas/ArtifactNodeView.tsx
@@ -47,6 +47,7 @@ export interface ArtifactMessage {
 
 export interface ArtifactNodeData extends Record<string, unknown> {
   artifactContent: string;
+  artifactError: string;
   history: ArtifactMessage[];
   isCollapsed: boolean;
   pendingRequestId: string | null;
@@ -147,6 +148,7 @@ export function artifactNodePropsAreEqual(
   const b = next.data;
   return (
     a.artifactContent === b.artifactContent &&
+    a.artifactError === b.artifactError &&
     a.isCollapsed === b.isCollapsed &&
     a.pendingRequestId === b.pendingRequestId &&
     a.onToggleCollapse === b.onToggleCollapse &&
@@ -209,6 +211,15 @@ export const ArtifactNodeView = memo(function ArtifactNodeView({
         )
       }
     >
+      {data.artifactError && (
+        // On the node, not only in a session-wide toast: with two artifact
+        // nodes on the canvas a toast cannot say which one failed. Same
+        // banner treatment the sandbox card uses for its own failures.
+        <div className="code-sandbox-node-banner-error" role="alert">
+          {data.artifactError}
+        </div>
+      )}
+
       <div className="artifact-node-document">
         {hasContent ? (
           <div className="chat-node-content artifact-node-document-content">

--- a/web_ui/src/app/canvas/SceneCanvas.pinSearchJump.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.pinSearchJump.test.tsx
@@ -101,7 +101,7 @@ function chatRow(id: string, x: number, y: number, title = id): SceneNodeRow {
         isDocked: false, imageAssetId: "", history: [], pendingRequestId: null,
         researchStage: "", researchCompleted: 0, researchTotal: 0,
         researchActiveSourceId: null, researchError: "", researchResult: null, researchRetainToKnowledge: false,
-        artifactContent: "", gitlinkRepo: "", gitlinkBranch: "",
+        artifactContent: "", artifactError: "", gitlinkRepo: "", gitlinkBranch: "",
         gitlinkScopeMode: "selected", gitlinkLocalRoot: "", gitlinkRepoFilePaths: [],
         gitlinkSelectedPaths: [], gitlinkTaskPrompt: "", gitlinkContextStats: {},
         gitlinkContextSummary: "", gitlinkContextVersion: 0,

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -73,6 +73,7 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
     researchResult: null,
     researchRetainToKnowledge: false,
     artifactContent: "",
+    artifactError: "",
     gitlinkRepo: "",
     gitlinkBranch: "",
     gitlinkScopeMode: "selected",

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -1563,6 +1563,7 @@ export function toFlowNodes(
         style: dimmedVal ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           artifactContent: n.artifactContent,
+          artifactError: n.artifactError,
           history: n.history,
           isCollapsed: n.isCollapsed,
           pendingRequestId: n.pendingRequestId ?? null,

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -146,7 +146,7 @@ function chatRow(id: string, x: number, y = 0): SceneNodeRow {
         isDocked: false, imageAssetId: "", history: [], pendingRequestId: null,
         researchStage: "", researchCompleted: 0, researchTotal: 0,
         researchActiveSourceId: null, researchError: "", researchResult: null, researchRetainToKnowledge: false,
-        artifactContent: "", gitlinkRepo: "", gitlinkBranch: "",
+        artifactContent: "", artifactError: "", gitlinkRepo: "", gitlinkBranch: "",
         gitlinkScopeMode: "selected", gitlinkLocalRoot: "", gitlinkRepoFilePaths: [],
         gitlinkSelectedPaths: [], gitlinkTaskPrompt: "", gitlinkContextStats: {},
         gitlinkContextSummary: "", gitlinkContextVersion: 0,

--- a/web_ui/src/app/canvas/renderCountGate.test.tsx
+++ b/web_ui/src/app/canvas/renderCountGate.test.tsx
@@ -121,7 +121,7 @@ function chatRow(id: string, x: number): SceneNodeRow {
         isDocked: false, imageAssetId: "", history: [], pendingRequestId: null,
         researchStage: "", researchCompleted: 0, researchTotal: 0,
         researchActiveSourceId: null, researchError: "", researchResult: null, researchRetainToKnowledge: false,
-        artifactContent: "", gitlinkRepo: "", gitlinkBranch: "",
+        artifactContent: "", artifactError: "", gitlinkRepo: "", gitlinkBranch: "",
         gitlinkScopeMode: "selected", gitlinkLocalRoot: "", gitlinkRepoFilePaths: [],
         gitlinkSelectedPaths: [], gitlinkTaskPrompt: "", gitlinkContextStats: {},
         gitlinkContextSummary: "", gitlinkContextVersion: 0,

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -152,7 +152,7 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         researchTotal: 0,
         researchError: "",
         researchRetainToKnowledge: false,
-        artifactContent: "",
+        artifactContent: "", artifactError: "",
         gitlinkRepo: "",
         gitlinkBranch: "",
         gitlinkScopeMode: "selected",

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -59,6 +59,9 @@
           "artifactContent": {
             "type": "string"
           },
+          "artifactError": {
+            "type": "string"
+          },
           "attachmentKind": {
             "type": "string"
           },
@@ -826,6 +829,7 @@
           "researchError",
           "researchRetainToKnowledge",
           "artifactContent",
+          "artifactError",
           "gitlinkRepo",
           "gitlinkBranch",
           "gitlinkScopeMode",

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -31,6 +31,7 @@ export interface SceneNodeRow {
   researchResult?: ResearchResultRow | null;
   researchRetainToKnowledge: boolean;
   artifactContent: string;
+  artifactError: string;
   gitlinkRepo: string;
   gitlinkBranch: string;
   gitlinkScopeMode: string;
@@ -417,6 +418,11 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["artifactContent"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.artifactContent: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.artifactContent` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["artifactError"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.artifactError: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.artifactError` + ": expected string"); }
   }
   {
     const fieldValue = value["gitlinkRepo"];


### PR DESCRIPTION
## Problem

Three related gaps in how the plugin node kinds handle asynchronous work.

**Artifact could not report a failure.** `ArtifactState` carried exactly one field, `artifact_content`, so a failed generation surfaced only through a session-wide notification toast - with two artifact nodes on a canvas there was no way to tell which one failed. Web Research already keeps `research_error` on the node, and Gitlink and Code Sandbox render their own in-card banners.

**Artifact and Web Research allowed one run at a time across the whole canvas.** `RunRegistry.is_busy()` is kind-scoped and session-wide - `RunHandle`'s own docstring states `node_id` is *"informational only … NEVER consulted"* - so a second research node could not start while an unrelated one was in flight, on a canvas whose premise is parallel branches, and the refusal could not name the node holding the slot. Gitlink and Code Sandbox already guard per node.

**Five plugins demanded a selection they never used.** Only HTML Renderer genuinely needs a parent: its factory seeds the new node's content from `document.nodes[parent_node_id].content`. The other five used `parent_node_id` as a `place_child` anchor and an edge, nothing more - so requiring a selection made the picker a dead end on an empty canvas.

## Change

**Failures on the node** - `artifact_error` joins `artifactContent` on the wire, rendered in the card with the same banner treatment the sandbox uses. Live-wire only: `research_error` appears in neither `session_save.py` nor `session_load.py`, so a reloaded session does not resurrect a stale failure. Cleared when a new instruction is sent and when a turn lands.

**Per-node runs** - both kinds move onto the `node.pending_request_id` guard Gitlink and Code Sandbox established, and name the busy node. Two details that guard shape demands:

- The stamp moves out of `_run()` to immediately after the claim, and the WS wrapper claims a placeholder synchronously before its first `await`. The field is the gate now, not UI bookkeeping, and a value written after an `await` leaves a window where a second click on one node sees an idle node. Same mechanism as `_GITLINK_RUN_CLAIM_PLACEHOLDER`.
- Busy means "the registry still holds this run", not "the node has a request id". Cancelling releases the slot at once while the worker unwinds in its own time, and during that window the node still carries the dead id - reading the field alone refused the very next Run clicked after a cancel. `AgentDispatcher.is_node_run_live` asks the registry.

`test_dispatch_claim_ordering.py`'s AST guard now covers both guard shapes rather than only the `is_busy()` one, so the no-await-between-guard-and-claim property stays enforced for the two converted kinds instead of silently going unchecked.

**Parentless creation** - `make_simple_child_node_handler` gains an opt-in standalone path that spawns at the picker's reported viewport centre and leaves the node unconnected. The five `add_*_node` methods already tolerated `parent_id=None` internally, so only their annotations widened. HTML Renderer is unchanged.

Also removes the `Validation & Delivery` picker category, which carried a full name and description, zero plugins, and was skipped at render.

## Test plan

- Full backend suite on a clean checkout of this branch: 3092 passed, 19 skipped. `ruff` clean. `python contracts/codegen.py --check`: 13 artifact sets up to date after regeneration.
- `npm run check` (schema drift, typecheck, lint, vitest, build, bundle size): green.
- `npx playwright test`: 5/5 - the specs bootstrap through the Plugins picker, which the parentless change touches.
- New backend coverage: `fail_artifact_generation` records the message, no-ops on a deleted node, and is cleared by both a new instruction and a landed turn; two web-research nodes hold in-flight runs simultaneously; a second run on the *same* node is bounced without overwriting its query, with the node-named message; **cancelling frees the node for an immediate re-run** (the regression the liveness check exists for); each of the five plugins creates an unconnected node at the reported spawn point and treats a stale selection as no selection, while HTML Renderer still refuses.
- Per-builtin parent behavior is now pinned once, exhaustively, in `test_plugin_builtin_migration.py`'s parametrized suite; ten near-identical per-plugin duplicates in `test_plugins.py` were replaced by a single test asserting the split itself.
- Frontend: the artifact card renders the failure banner with `role="alert"` and renders none when there is no error.
