### PR TITLE
Share the one blocking-action skeleton both dispatch mixins had copied

### DIFF
--- a/backend/agent_dispatch/code_review.py
+++ b/backend/agent_dispatch/code_review.py
@@ -6,11 +6,14 @@ class's shared state established by DispatcherCoreOps.__init__ - it is
 composed exactly once, by backend/agents.py's
 `class AgentDispatcher(DispatcherCoreOps, ...)`.
 
-Method bodies follow backend/agent_dispatch/gitlink.py's own shapes
-verbatim in structure (the plain-blocking-action skeleton with inline
-pending_request_id claim for fetch/ask; the fire-and-forget RunRegistry-
-claimed background task with cooperative cancel_event for the review run
-itself); only the Review Lens payloads differ. Any name that lives in
+Method bodies follow backend/agent_dispatch/gitlink.py's own shapes; only
+the Review Lens payloads differ. fetch/ask are plain blocking actions
+that claim node.pending_request_id inline - they share
+DispatcherCoreOps._run_node_blocking_action for that, rather than each
+feature mixin keeping its own copy of the skeleton (this module used to
+carry a byte-identical duplicate of gitlink's). The review run itself is
+a fire-and-forget RunRegistry-claimed background task with a cooperative
+cancel_event, still shaped like start_gitlink_run. Any name that lives in
 backend/agents.py's module namespace (module helpers, constants, names
 imported into it) is accessed late-bound as `agents_module.<name>`
 through an in-body deferred import, NEVER via a module-top import here: a
@@ -26,7 +29,6 @@ from __future__ import annotations
 
 import asyncio
 import threading
-import uuid
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -36,54 +38,12 @@ if TYPE_CHECKING:
 class CodeReviewDispatchOps:
     """Review Lens dispatch: PR-diff fetch plus the Review and Ask surfaces (mixin - see module docstring)."""
 
-    async def _run_code_review_blocking_action(
-        self,
-        *,
-        bus: SessionBus,
-        notifications_state,
-        node,
-        action,
-        timeout: float,
-        timeout_message: str,
-        error_log_message: str,
-        error_notify_prefix: str,
-        default=None,
-    ):
-        """Shared skeleton behind the two PLAIN code-review async methods
-        below (fetch_code_review_diff/ask_code_review_question) - the same
-        shape as GitlinkDispatchOps._run_gitlink_blocking_action: these two
-        (unlike start_code_review_run) claim node.pending_request_id inline
-        and are awaited directly by the caller, with no RunRegistry/
-        cancel_event involvement. `action` is a zero-arg async callable
-        doing the actual blocking work (already wrapped in asyncio.to_thread
-        by the caller); everything around it - the busy marker
-        claim/release, the "scene" publishes bracketing it, and the
-        timeout/exception -> notification handling - is shared."""
-        from backend import agents as agents_module  # deferred: patch-seam + circular-import safety
-        request_id = uuid.uuid4().hex
-        node.pending_request_id = request_id
-        await bus.publish("scene")
-        try:
-            return await asyncio.wait_for(action(), timeout=timeout)
-        except asyncio.TimeoutError:
-            notifications_state.show(timeout_message, "error")
-            await bus.publish("notification")
-            return default
-        except Exception as exc:
-            agents_module.logger.exception(error_log_message)
-            notifications_state.show(f"{error_notify_prefix}: {exc}", "error")
-            await bus.publish("notification")
-            return default
-        finally:
-            node.pending_request_id = None
-            await bus.publish("scene")
-
     async def fetch_code_review_diff(self, *, bus: SessionBus, notifications_state, node, pr_url: str):
         from backend import agents as agents_module  # deferred: patch-seam + circular-import safety
         async def _action():
             return await asyncio.to_thread(agents_module._fetch_code_review_bundle, self._settings_manager, pr_url)
 
-        return await self._run_code_review_blocking_action(
+        return await self._run_node_blocking_action(
             bus=bus,
             notifications_state=notifications_state,
             node=node,
@@ -198,7 +158,7 @@ class CodeReviewDispatchOps:
                 agents_module._ask_review_lens_agent, diff_text, question, review_summary,
             )
 
-        return await self._run_code_review_blocking_action(
+        return await self._run_node_blocking_action(
             bus=bus,
             notifications_state=notifications_state,
             node=node,

--- a/backend/agent_dispatch/core.py
+++ b/backend/agent_dispatch/core.py
@@ -26,6 +26,7 @@ import asyncio
 import inspect
 import logging
 import threading
+import uuid
 
 from typing import TYPE_CHECKING
 
@@ -167,6 +168,60 @@ class DispatcherCoreOps:
         # the only state that must survive between runs is the plain string
         # node.state.code_sandbox_sandbox_id, real SceneNode state, not a
         # live object.
+
+    async def _run_node_blocking_action(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        node,
+        action,
+        timeout: float,
+        timeout_message: str,
+        error_log_message: str,
+        error_notify_prefix: str,
+        default=None,
+    ):
+        """The skeleton behind every PLAIN per-node async action - the ones
+        that claim node.pending_request_id inline and are awaited directly by
+        their caller, with no RunRegistry or cancel_event involvement (unlike
+        the start_* surfaces, which go through _dispatch or their own
+        fire-and-forget task).
+
+        `action` is a zero-arg async callable doing the actual blocking work,
+        already wrapped in asyncio.to_thread by the caller, including any
+        success-path transform of the thread result. Everything around it -
+        the busy-marker claim and release, the "scene" publishes bracketing
+        it, and the timeout/exception-to-notification handling - is shared.
+
+        Lives on the core rather than on a feature mixin because it is not
+        feature-specific: GitlinkDispatchOps extracted it for its own four
+        plain actions, then CodeReviewDispatchOps arrived and copied the
+        whole thing verbatim for its two - a helper written to remove
+        duplication, duplicated. Every dispatch mixin composes with this
+        class, so the next kind that needs the shape inherits it.
+
+        Callers: gitlink's fetch_repositories/load_repo_tree/import_snapshot/
+        build_context, and code review's fetch_diff/ask_question. Deliberately
+        NOT an exhaustive list to keep current - grep the name."""
+        from backend import agents as agents_module  # deferred: patch-seam + circular-import safety
+        request_id = uuid.uuid4().hex
+        node.pending_request_id = request_id
+        await bus.publish("scene")
+        try:
+            return await asyncio.wait_for(action(), timeout=timeout)
+        except asyncio.TimeoutError:
+            notifications_state.show(timeout_message, "error")
+            await bus.publish("notification")
+            return default
+        except Exception as exc:
+            agents_module.logger.exception(error_log_message)
+            notifications_state.show(f"{error_notify_prefix}: {exc}", "error")
+            await bus.publish("notification")
+            return default
+        finally:
+            node.pending_request_id = None
+            await bus.publish("scene")
 
     def _runtime_kwargs(self) -> dict:
         """ADR-006 stage 6.5: `{"runtime": self._provider_runtime}` for a

--- a/backend/agent_dispatch/gitlink.py
+++ b/backend/agent_dispatch/gitlink.py
@@ -7,8 +7,12 @@ composed exactly once, by backend/agents.py's
 `class AgentDispatcher(DispatcherCoreOps, ...)`.
 
 Method bodies are relocated VERBATIM from backend/agents.py; only the class
-wrapper, imports, and the patch-seam rewrites below are new. Any name that
-lives in backend/agents.py's module namespace (module helpers, constants,
+wrapper, imports, and the patch-seam rewrites below are new. The one later
+departure: the plain-blocking-action skeleton the four repository plumbing
+methods share was extracted here first, then copied verbatim into
+code_review.py - it now lives on DispatcherCoreOps as
+_run_node_blocking_action, where every dispatch mixin already has it. Any
+name that lives in backend/agents.py's module namespace (module helpers,
 names imported into it) is accessed late-bound as `agents_module.<name>`
 through an in-body deferred import, NEVER via a module-top import here: a
 top-level `from backend.agents import X` would be a circular import
@@ -23,7 +27,6 @@ from __future__ import annotations
 
 import asyncio
 import threading
-import uuid
 from pathlib import Path
 
 from typing import TYPE_CHECKING
@@ -35,57 +38,12 @@ if TYPE_CHECKING:
 class GitlinkDispatchOps:
     """Gitlink dispatch: repo plumbing plus the Run and Apply surfaces (mixin - see module docstring)."""
 
-    async def _run_gitlink_blocking_action(
-        self,
-        *,
-        bus: SessionBus,
-        notifications_state,
-        node,
-        action,
-        timeout: float,
-        timeout_message: str,
-        error_log_message: str,
-        error_notify_prefix: str,
-        default=None,
-    ):
-        """Shared skeleton behind the four PLAIN gitlink async methods below
-        (fetch_gitlink_repositories/load_gitlink_repo_tree/
-        import_gitlink_snapshot/build_gitlink_context) - see the comment
-        above `fetch_gitlink_repositories` for why these four (unlike
-        start_gitlink_run/start_gitlink_apply) claim node.pending_request_id
-        inline and are awaited directly by the caller, with no
-        RunRegistry/cancel_event involvement. `action` is a zero-arg async
-        callable doing the actual blocking work (already wrapped in
-        asyncio.to_thread by the caller, including any success-path
-        transform of the thread result); everything around it - the busy
-        marker claim/release, the "scene" publishes bracketing it, and the
-        timeout/exception -> notification handling - was identical across
-        all four before this extraction."""
-        from backend import agents as agents_module  # deferred: patch-seam + circular-import safety
-        request_id = uuid.uuid4().hex
-        node.pending_request_id = request_id
-        await bus.publish("scene")
-        try:
-            return await asyncio.wait_for(action(), timeout=timeout)
-        except asyncio.TimeoutError:
-            notifications_state.show(timeout_message, "error")
-            await bus.publish("notification")
-            return default
-        except Exception as exc:
-            agents_module.logger.exception(error_log_message)
-            notifications_state.show(f"{error_notify_prefix}: {exc}", "error")
-            await bus.publish("notification")
-            return default
-        finally:
-            node.pending_request_id = None
-            await bus.publish("scene")
-
     async def fetch_gitlink_repositories(self, *, bus: SessionBus, notifications_state, node) -> list[str]:
         from backend import agents as agents_module  # deferred: patch-seam + circular-import safety
         async def _action():
             return await asyncio.to_thread(agents_module._list_github_repositories, self._settings_manager)
 
-        return await self._run_gitlink_blocking_action(
+        return await self._run_node_blocking_action(
             bus=bus,
             notifications_state=notifications_state,
             node=node,
@@ -105,7 +63,7 @@ class GitlinkDispatchOps:
         async def _action():
             return await asyncio.to_thread(agents_module._load_gitlink_tree, self._settings_manager, repo, branch)
 
-        return await self._run_gitlink_blocking_action(
+        return await self._run_node_blocking_action(
             bus=bus,
             notifications_state=notifications_state,
             node=node,
@@ -132,7 +90,7 @@ class GitlinkDispatchOps:
             )
             return resolved_repo, resolved_branch, str(local_root_path)
 
-        return await self._run_gitlink_blocking_action(
+        return await self._run_node_blocking_action(
             bus=bus,
             notifications_state=notifications_state,
             node=node,
@@ -164,7 +122,7 @@ class GitlinkDispatchOps:
                 imported_root_hint=node.state.gitlink_imported_root,
             )
 
-        return await self._run_gitlink_blocking_action(
+        return await self._run_node_blocking_action(
             bus=bus,
             notifications_state=notifications_state,
             node=node,


### PR DESCRIPTION
## Problem

`GitlinkDispatchOps` extracted `_run_gitlink_blocking_action` to remove the duplication across its four plain repository actions. `CodeReviewDispatchOps` then copied that helper verbatim for its own two — an extraction made to remove duplication, duplicated.

The two bodies were byte-identical. An AST comparison with docstrings stripped matched exactly, 18 statements each; only the method name and the docstring differed. A repo-wide clone scan over ~130k lines of Python found just two exact duplicate function bodies, and this was one of them.

## Change

The helper moves to `DispatcherCoreOps` as `_run_node_blocking_action`.

The shape is not feature-specific: claim `node.pending_request_id`, publish `"scene"`, await a caller-supplied blocking action under a timeout, turn a timeout or an exception into a notification, release and publish again. Every dispatch mixin already composes with the core, so the next node kind that needs it inherits it rather than pasting a third copy.

All six call sites (gitlink's four, code review's two) are unchanged apart from the name. The relocated body is the same statements in the same order, including the deferred `from backend import agents` import the mixins rely on as a test patch seam.

Both modules' docstrings described the skeleton as their own. They now point at the shared one and record why it moved — `gitlink.py`'s in particular claimed its method bodies were "relocated VERBATIM from `backend/agents.py`", which stops being true for this one method.

## Test plan

No new tests. This is a pure relocation with no behavioural surface of its own, and the six call sites are already covered by the existing gitlink and Review Lens dispatch suites, which exercise the success, timeout and failure paths through it.

- Full suite: **3138 passed, 19 skipped**. `ruff check .` clean.
- Asserted directly that neither feature module still defines a blocking-action helper, and that `AgentDispatcher` resolves `_run_node_blocking_action` from `DispatcherCoreOps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
