### PR TITLE
Repair three quality gates that had stopped doing their job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,9 +234,16 @@ jobs:
         working-directory: web_ui
         run: npm ci
 
+      # Wrapped rather than a bare `npm audit --audit-level=high`: that
+      # conflates "this dependency set has a high-severity advisory" with
+      # "registry.npmjs.org did not answer" into the same exit code, and the
+      # second failed two consecutive Python-only pull requests in one
+      # afternoon. See web_ui/scripts/audit-with-retry.mjs's own header for
+      # the full reasoning and the trade it makes. A real advisory still
+      # fails the build on the first attempt.
       - name: npm audit (known-vulnerability scan, high+critical only)
         working-directory: web_ui
-        run: npm audit --audit-level=high
+        run: node scripts/audit-with-retry.mjs
 
       - name: Run checks (schema drift, typecheck, lint, vitest, build)
         working-directory: web_ui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,25 @@ filterwarnings = [
     # removal) - backend/tests/test_builder.py's one call is a documented
     # no-op probe (see that test's own comment), not a real usage to migrate.
     "ignore:'asyncio.get_event_loop_policy' is deprecated.*:DeprecationWarning",
+    # 2026-09-04 audit: the three error:: lines above cannot see a starlette
+    # deprecation at all. StarletteDeprecationWarning subclasses UserWarning,
+    # not DeprecationWarning - so the one policy written to catch "a
+    # dependency bump silently breaking at the next major version" was
+    # structurally blind to the dependency that has already announced one.
+    # Named by its defining module (starlette.exceptions) rather than
+    # starlette.testclient, which re-exports it but emits the warning below
+    # on import - pytest resolves this path while loading the config.
+    "error::starlette.exceptions.StarletteDeprecationWarning",
+    # The one starlette deprecation live today, recorded rather than
+    # silently passed. Every run emits it; the whole TestClient surface
+    # depends on it (test_ws_origin, test_http_trust_boundary,
+    # test_security_invariants, test_auth, test_session_lifecycle and four
+    # more). Clearing it means moving the test client onto httpx2, which is
+    # a hash-locked dependency change and its own reviewed piece of work,
+    # not a warnings-policy edit. Until then the error:: line above means a
+    # SECOND starlette deprecation fails the build instead of hiding behind
+    # this one.
+    "ignore:Using `httpx` with `starlette.testclient` is deprecated.*:starlette.exceptions.StarletteDeprecationWarning",
 ]
 # Hang diagnosis. pytest's built-in faulthandler dumps a full traceback of
 # every thread if any single test runs longer than this, naming the exact

--- a/web_ui/scripts/audit-with-retry.mjs
+++ b/web_ui/scripts/audit-with-retry.mjs
@@ -1,0 +1,127 @@
+// The npm vulnerability scan, with the registry's own availability separated
+// from the thing being scanned.
+//
+// `npm audit --audit-level=high` conflates two completely different outcomes
+// into exit code 1: "this dependency set has a high-severity advisory" and
+// "registry.npmjs.org did not answer". Only the first is a reason to block a
+// merge. The second took down two consecutive, Python-only pull requests in
+// one afternoon (2026-09-04: a 503, then a network timeout, each after
+// hanging ~5 minutes), and in the checks UI it is indistinguishable from a
+// real security failure - so the reflex becomes "just re-run it", which is
+// exactly the reflex that eventually gets applied to a genuine finding too.
+//
+// The two ARE distinguishable through --json: on a real finding npm exits
+// non-zero AND writes a report carrying metadata.vulnerabilities; on an
+// endpoint error it exits non-zero having written no usable report (often
+// still valid JSON - an {error: ...} object - which is why classifyAuditRun
+// looks for the counts block specifically, not merely for parseable output).
+//
+// So: a real advisory fails on the first attempt, unchanged. A registry
+// error is retried three times, backing off, and if the endpoint is still
+// unreachable the run continues with a CI annotation saying plainly that the
+// scan did NOT run. That last part is the deliberate trade - a registry
+// outage is not evidence of a clean dependency set, and passing silently
+// would be worse than passing loudly.
+//
+// Run from web_ui/ by the frontend-checks job. Node rather than a shell blob
+// with jq: that job already has node, and it matches check-bundle-size.mjs's
+// own shape. classifyAuditRun is exported and unit-tested
+// (audit-with-retry.test.mjs) because it is the part that decides whether a
+// merge is blocked, and a guard nobody tested is how this gate got its
+// reputation in the first place.
+
+import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const ATTEMPTS = 3;
+export const AUDIT_LEVEL = "high";
+
+/**
+ * Decide what one `npm audit --json` run actually told us.
+ *
+ * @returns {"clean"|"finding"|"unavailable"}
+ *   clean       - npm exited 0: nothing at or above AUDIT_LEVEL.
+ *   finding     - npm exited non-zero AND produced a real report: block.
+ *   unavailable - npm exited non-zero with no usable report: the registry
+ *                 did not answer, which says nothing about the dependencies.
+ */
+export function classifyAuditRun({ status, stdout }) {
+  if (status === 0) return "clean";
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout || "");
+  } catch {
+    return "unavailable";
+  }
+  const counts = parsed && parsed.metadata && parsed.metadata.vulnerabilities;
+  return counts && typeof counts === "object" ? "finding" : "unavailable";
+}
+
+/** The high/critical entries a "finding" report names, for the failure log. */
+export function severeEntries(report) {
+  return Object.entries((report && report.vulnerabilities) || {})
+    .filter(([, entry]) => entry && (entry.severity === "high" || entry.severity === "critical"))
+    .map(([name, entry]) => `${entry.severity}\t${name}`);
+}
+
+// -- everything below is the CLI shell around the two functions above -------
+
+// True only when this file was invoked directly, so importing it from the
+// test does not kick off a real audit.
+const isMain =
+  !!process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+
+function runAudit() {
+  // shell:true on Windows because npm is npm.cmd there, and Node refuses to
+  // spawn .cmd without a shell. CI is ubuntu, where the direct spawn works -
+  // this is purely so the script is runnable on a maintainer's machine.
+  return spawnSync("npm", ["audit", `--audit-level=${AUDIT_LEVEL}`, "--json"], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    shell: process.platform === "win32",
+  });
+}
+
+const sleep = (ms) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+
+function main() {
+  const isCi = !!process.env.GITHUB_ACTIONS;
+
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
+    const result = runAudit();
+    const verdict = classifyAuditRun(result);
+
+    if (verdict === "clean") {
+      console.log(`npm audit: no ${AUDIT_LEVEL} or critical advisories.`);
+      return 0;
+    }
+
+    if (verdict === "finding") {
+      // A real finding fails immediately - retrying a genuine advisory would
+      // only delay it.
+      const report = JSON.parse(result.stdout);
+      console.error(
+        `npm audit FAILED: ${AUDIT_LEVEL}+ advisories in the dependency set.\n` +
+          `  counts: ${JSON.stringify(report.metadata.vulnerabilities)}`,
+      );
+      for (const line of severeEntries(report)) console.error(`  - ${line}`);
+      return 1;
+    }
+
+    console.log(
+      `npm audit: the registry returned no usable report (attempt ${attempt}/${ATTEMPTS}).` +
+        (result.stderr ? `\n${result.stderr.trim().split("\n").slice(-3).join("\n")}` : ""),
+    );
+    if (attempt < ATTEMPTS) sleep(attempt * 10_000);
+  }
+
+  const message =
+    `npm audit could not reach the registry after ${ATTEMPTS} attempts - the vulnerability ` +
+    "scan did NOT run for this build. This is a registry availability problem, not a clean " +
+    "result; re-run the job once the registry is healthy.";
+  console.log(isCi ? `::warning::${message}` : `WARNING: ${message}`);
+  return 0;
+}
+
+if (isMain) process.exit(main());

--- a/web_ui/scripts/audit-with-retry.test.mjs
+++ b/web_ui/scripts/audit-with-retry.test.mjs
@@ -1,0 +1,73 @@
+// Guard the guard: audit-with-retry.mjs decides whether a merge is blocked,
+// so the decision itself gets tested rather than trusted. Same posture as
+// check-bundle-size.mjs's "guards the guard" empty-assets branch, and the
+// backend's own AST-scan gates.
+//
+// The process/retry shell around classifyAuditRun is deliberately NOT tested
+// here: stubbing `npm` cross-platform is more machinery than it is worth, and
+// the shell is a thin loop over the three verdicts below. What matters - and
+// what the real npm audit conflates - is which of those three a given run is.
+
+import { describe, expect, it } from "vitest";
+
+import { classifyAuditRun, severeEntries } from "./audit-with-retry.mjs";
+
+const REAL_FINDING = JSON.stringify({
+  metadata: { vulnerabilities: { info: 0, low: 0, moderate: 1, high: 2, critical: 1 } },
+  vulnerabilities: {
+    lodash: { severity: "high" },
+    minimist: { severity: "critical" },
+    qs: { severity: "moderate" },
+  },
+});
+
+describe("classifyAuditRun", () => {
+  it("treats a zero exit as clean", () => {
+    expect(classifyAuditRun({ status: 0, stdout: "{}" })).toBe("clean");
+  });
+
+  it("treats a non-zero exit WITH a real report as a finding", () => {
+    expect(classifyAuditRun({ status: 1, stdout: REAL_FINDING })).toBe("finding");
+  });
+
+  it("treats a non-zero exit with unparseable output as unavailable", () => {
+    // The 503 shape: npm printed a human error, not JSON.
+    expect(classifyAuditRun({ status: 1, stdout: "npm error audit endpoint returned an error" }))
+      .toBe("unavailable");
+  });
+
+  it("treats a non-zero exit with an error OBJECT as unavailable, not a finding", () => {
+    // The subtle one. npm can emit valid JSON that is still not a report -
+    // checking merely "did it parse" would classify a registry outage as a
+    // security finding and block every merge during one.
+    expect(classifyAuditRun({ status: 1, stdout: '{"error":{"code":"E503"}}' })).toBe("unavailable");
+  });
+
+  it("treats a non-zero exit with no output at all as unavailable", () => {
+    // The network-timeout shape: npm died before writing anything.
+    expect(classifyAuditRun({ status: 1, stdout: "" })).toBe("unavailable");
+    expect(classifyAuditRun({ status: null, stdout: undefined })).toBe("unavailable");
+  });
+
+  it("does not mistake an empty-but-present counts block for an outage", () => {
+    // A clean-at-this-level report still carries counts; if npm ever exits
+    // non-zero with one, that is a finding to surface, not a network problem.
+    expect(classifyAuditRun({ status: 1, stdout: '{"metadata":{"vulnerabilities":{}}}' }))
+      .toBe("finding");
+  });
+});
+
+describe("severeEntries", () => {
+  it("lists only high and critical entries", () => {
+    const lines = severeEntries(JSON.parse(REAL_FINDING));
+    expect(lines).toHaveLength(2);
+    expect(lines.join("\n")).toContain("lodash");
+    expect(lines.join("\n")).toContain("minimist");
+    expect(lines.join("\n")).not.toContain("qs");
+  });
+
+  it("survives a report with no vulnerabilities block", () => {
+    expect(severeEntries({})).toEqual([]);
+    expect(severeEntries(null)).toEqual([]);
+  });
+});

--- a/web_ui/scripts/check-bundle-size.mjs
+++ b/web_ui/scripts/check-bundle-size.mjs
@@ -93,6 +93,39 @@ const ASSETS_DIR = join(HERE, "..", "dist", "app", "assets");
 // 1,423,000-ceiling -> 1,445,539 bytes (+22,539, ~1.6%). No chunk grew
 // from a dependency (imports are the existing shared card components -
 // NodeShell/NodeMenu/NodeMarkdown/CollapseToggleButton - plus React).
+//
+// CORRECTION - 2026-09-04 (QA audit).
+//
+// The amendment immediately above measures its own delta from the previous
+// CEILING (866,000) instead of the previous MEASUREMENT (841,347, recorded
+// by the 08-19 amendment). Review Lens did not cost +24,541 bytes; against
+// the last number this file actually recorded it cost +49,194 (+5.8%),
+// roughly double. The ceiling itself is not wrong - 917,000 is ~3% over the
+// real 890,541, the posture every amendment here has chosen - but the
+// arithmetic explaining it is, and a ratchet whose audit trail is wrong
+// cannot be reasoned about later.
+//
+// The gap is drift, and it went unattributed exactly as before: `git log`
+// shows 39 commits touching web_ui/src between the 08-19 amendment and
+// Review Lens, and NONE of them touched this file. Both prior amendments
+// were written about this same recurrence ("Drift, again, unattributed...
+// conflating them is how a ratchet dies quietly"), which makes this the
+// third time, and the first two were only caught after the gate had already
+// stopped being able to catch anything - 323 bytes of headroom in August,
+// 1,293 in September.
+//
+// So the numbers below are re-anchored to measured reality, and the script
+// now prints its own headroom and raises a CI annotation when that headroom
+// gets thin (see HEADROOM_WARN_RATIO). A warning, deliberately not a
+// failure: drift is nobody's individual fault, and failing an unrelated PR
+// for it is the false alarm the 08-12 amendment was itself written about.
+// Somebody has to see the erosion while there is still room to act on it.
+//
+// The underlying ADR-019 budget for the initial chunk is still 500 KiB
+// (512,000 bytes) and 890,541 is ~74% over it. This ceiling remains a
+// regression ratchet, not the budget. Closing the real gap still needs the
+// 17 eagerly-rendered node views in SceneCanvas.tsx code-split - work no
+// stage owns.
 const LARGEST_CHUNK_CEILING_BYTES = 917_000;
 // Post-11.6 reality: six chunks (main + katex + highlight.js + the three
 // lazy dialogs) total 1,288,075 bytes - essentially unchanged from the
@@ -112,6 +145,14 @@ const LARGEST_CHUNK_CEILING_BYTES = 917_000;
 // ceiling down again in a later stage that shrinks the total, per this
 // file's own ratchet discipline above.
 const TOTAL_JS_CEILING_BYTES = 1_489_000;
+
+// Below this much headroom, say so. Both prior amendments record the same
+// story: the ceiling was set with ~3-5% room, ordinary week-to-week growth
+// ate it silently, and the erosion was only noticed once the gate had 0.04%
+// (August) and 0.15% (September) left - at which point the next unrelated
+// change tripped it and looked like the culprit. 1.5% would have surfaced
+// both while there was still room to re-anchor deliberately.
+const HEADROOM_WARN_RATIO = 0.015;
 
 let entries;
 try {
@@ -166,8 +207,34 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
+// Headroom is printed, not just the raw sizes: the number that actually
+// predicts a false alarm is how much room is left, and it was never on
+// screen. A CI annotation (rather than a buried log line) is what gets it in
+// front of someone while re-anchoring is still a deliberate choice.
+const headroom = (bytes, ceiling) => (ceiling - bytes) / ceiling;
+const asPercent = (ratio) => `${(ratio * 100).toFixed(1)}%`;
+const chunkHeadroom = headroom(chunks[0].bytes, LARGEST_CHUNK_CEILING_BYTES);
+const totalHeadroom = headroom(totalBytes, TOTAL_JS_CEILING_BYTES);
+
+for (const [label, bytes, ceiling, room] of [
+  ["largest chunk", chunks[0].bytes, LARGEST_CHUNK_CEILING_BYTES, chunkHeadroom],
+  ["total JS", totalBytes, TOTAL_JS_CEILING_BYTES, totalHeadroom],
+]) {
+  if (room >= HEADROOM_WARN_RATIO) continue;
+  const message =
+    `check-bundle-size: ${label} is ${bytes.toLocaleString()} bytes against a ` +
+    `${ceiling.toLocaleString()} ceiling - only ${asPercent(room)} headroom left. ` +
+    "Growth has been accumulating without the ceiling being re-anchored. Re-anchor it " +
+    "as a deliberate, commented amendment (ADR-019 §4) measured from the LAST RECORDED " +
+    "MEASUREMENT, not from the current ceiling, before an unrelated change trips it.";
+  // GitHub renders ::warning:: as an annotation on the run; elsewhere it is
+  // just a line, which is why the prefix is conditional rather than always on.
+  console.log(process.env.GITHUB_ACTIONS ? `::warning::${message}` : `WARNING: ${message}`);
+}
+
 console.log(
   `check-bundle-size OK: largest chunk ${chunks[0].bytes.toLocaleString()} bytes ` +
-    `(ceiling ${LARGEST_CHUNK_CEILING_BYTES.toLocaleString()}), ` +
-    `total ${totalBytes.toLocaleString()} bytes (ceiling ${TOTAL_JS_CEILING_BYTES.toLocaleString()}).`,
+    `(ceiling ${LARGEST_CHUNK_CEILING_BYTES.toLocaleString()}, ${asPercent(chunkHeadroom)} headroom), ` +
+    `total ${totalBytes.toLocaleString()} bytes ` +
+    `(ceiling ${TOTAL_JS_CEILING_BYTES.toLocaleString()}, ${asPercent(totalHeadroom)} headroom).`,
 );


### PR DESCRIPTION
## Problem

Three gates that run on every PR and reported cleanly. Two passed when they should not have; one failed when it should not have.

### 1. The warnings policy is blind to the deprecation that is actually pending

`filterwarnings` promotes `DeprecationWarning`, `PendingDeprecationWarning` and `FutureWarning` to errors, for the reason its own comment gives — catching "a dependency bump silently breaking at the next major version".

`StarletteDeprecationWarning` subclasses `UserWarning`:

```
StarletteDeprecationWarning.__mro__
  -> [StarletteDeprecationWarning, UserWarning, Warning, Exception, ...]
```

None of those three lines can see it. And starlette is the dependency that has already announced a break — every warning in a green run today, all six, is the same one:

```
StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is
deprecated; install `httpx2` instead.
```

That reaches the whole `TestClient` surface: `test_ws_origin`, `test_http_trust_boundary`, `test_security_invariants`, `test_auth`, `test_session_lifecycle` and four more.

### 2. The bundle ratchet's audit trail had gone wrong

The 2026-09-03 amendment records Review Lens's cost as "866,000-ceiling -> 890,541 bytes (+24,541, ~2.8%)". The 08-19 amendment recorded the *measurement* as 841,347. Measured from the last recorded measurement rather than from the ceiling, the real delta is **+49,194 (+5.8%)** — roughly double.

The ceiling itself is fine; 917,000 is ~3% over the real 890,541. The gap is drift, unattributed exactly as before: **39 commits touched `web_ui/src` between the 08-19 amendment and Review Lens, and none of them touched this file.**

Both prior amendments were written about this same recurrence — *"Drift, again, unattributed... conflating them is how a ratchet dies quietly"* — making this the third. The first two were only caught once the gate had 323 bytes (August) and 1,293 bytes (September) of headroom left, at which point the next unrelated change tripped it and looked like the culprit.

### 3. `npm audit` fails the build when npmjs.org is unwell

Found by hitting it twice while landing the other two. `npm audit --audit-level=high` conflates "this dependency set has a high-severity advisory" with "the registry did not answer" into one exit code. The second took down two consecutive **Python-only** pull requests in one afternoon:

```
#393  npm warn audit 503 Service Unavailable - POST .../advisories/bulk
#394  npm warn audit network timeout at: .../advisories/bulk
```

Each hung ~5 minutes first, and in the checks UI it is indistinguishable from a real security failure — so the reflex becomes "just re-run it", which is the reflex that eventually gets applied to a genuine finding too.

## Change

**Warnings policy.** `StarletteDeprecationWarning` is named by its defining module — `starlette.exceptions`, not `starlette.testclient`, which re-exports it but emits the warning on import while pytest is still loading config. The known `httpx` one is a targeted `ignore:` carrying its remediation, so a *second* starlette deprecation fails the build instead of hiding behind it. Clearing the known one means moving the test client onto httpx2 — a hash-locked dependency change and its own reviewed work.

**Bundle ratchet.** The arithmetic is corrected in place with the real figures. The script now prints its own headroom and raises a GitHub annotation below 1.5%, naming the correct baseline to re-anchor from. A warning, deliberately not a failure: drift is nobody's individual fault, and failing an unrelated PR for it is exactly the false alarm the 08-12 amendment complained about. 1.5% would have surfaced both prior incidents with room to act.

**npm audit.** The two outcomes are distinguishable through `--json` — a real finding exits non-zero *and* writes a report carrying `metadata.vulnerabilities`; an endpoint error exits non-zero with no usable report (often still valid JSON, an `{error: ...}` object, which is why the check looks for the counts block rather than merely for parseable output). So a real advisory fails on the first attempt, unchanged; a registry error is retried three times; and a persistent outage annotates and continues rather than blocking every merge. Passing silently on an unreachable registry would be worse than passing loudly, hence the annotation stating plainly that the scan did not run.

It is a node script rather than a shell blob with `jq`: that job already has node, it matches `check-bundle-size.mjs`'s shape, and the classifier is unit-testable.

The ADR-019 budget is unchanged at 512,000 bytes. At 890,541 the initial chunk is ~74% over it, and closing that still needs the 17 eagerly-rendered node views in `SceneCanvas.tsx` code-split.

## Test plan

- Verified the new `error::` filter really fires, by raising a *different* `StarletteDeprecationWarning` from a throwaway test — it failed the run as intended — then removing it.
- Verified the headroom warning against the real bundle at a tightened ceiling: it prints, sets no failure (`exit=0`), and emits `::warning::` only under `GITHUB_ACTIONS`.
- **8 new vitest cases** over the audit classifier, covering the two shapes that matter most: a registry error that still emits valid JSON must not read as a finding, and a report with an empty counts block must.
- Ran the audit wrapper against the live registry: `no high or critical advisories`, exit 0.
- Full Python suite: **3138 passed, 19 skipped**, warning count in the summary line down from 6 to 0. Frontend `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
