### PR TITLE
Make the settings mixins type-checkable, and widen mypy onto them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,6 +292,17 @@ files = [
     "backend/events.py",
     "backend/token_counter.py",
     "graphlink_process_env.py",
+    # 2026-09-04: the first widening since this list was written, and the
+    # ratchet moving the direction its own comment asks for.
+    #
+    # settings_store/ used to report 115 errors, every one attr-defined, and
+    # 101 of those were three names: state, _save_state, _protect_and_track.
+    # The package was not badly typed, it was untypeable - a mixin cannot be
+    # checked in isolation when nothing declares what the class composing it
+    # provides. settings_store/_composed.py declares exactly that, in
+    # TYPE_CHECKING only, and the package now checks clean with no
+    # behavioural change. See that module's own docstring.
+    "settings_store",
 ]
 ignore_missing_imports = true
 

--- a/settings_store/_composed.py
+++ b/settings_store/_composed.py
@@ -1,0 +1,65 @@
+"""What every settings_store mixin relies on its composing class to provide.
+
+The ten `*Ops` classes in this package are mixins, not standalone types:
+each is composed exactly once, by graphlink_settings_store.py's
+`class SettingsManager(PersistenceOps, GeneralSettingsOps, ...)`. They
+freely use `self.state`, `self._save_state()` and the class constants
+(`self.NOTIFICATION_TYPES`, `self.REASONING_LEVELS`, ...) that only exist
+on the composed whole - correct at runtime, and completely invisible to a
+type checker looking at one mixin in isolation.
+
+That invisibility was not free. `mypy settings_store` reported 115 errors,
+every single one `attr-defined`, and 101 of them were just three names:
+`state` (66), `_save_state` (33) and `_protect_and_track` (2). The
+remaining 14 were class constants. In other words the package was not
+badly typed - it was untypeable, because nothing declared the contract
+between a mixin and the class that composes it. That is the same shape as
+the 23 `*Ops` mixins across backend/agent_dispatch/ and backend/domain/,
+and it is a large part of why `[tool.mypy].files` has stayed at four
+entries while the real error count grew from 642 to over a thousand.
+
+Declaring the contract in one place fixes all 115 without changing a line
+of behaviour.
+
+EVERYTHING HERE IS TYPE_CHECKING-ONLY. At runtime this class is empty, so
+inheriting it adds no attributes, no methods, and no `__init__` - the real
+implementations still come from PersistenceOps and from SettingsManager's
+own class body, exactly as before. It is a declaration of what the
+composed object has, not a second source of it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+
+class SettingsManagerParts:
+    """Type-only declaration of the composed SettingsManager's shared surface.
+
+    Mixins in this package inherit it so a checker can see what they use.
+    PersistenceOps inherits it too - it supplies `state`/`_save_state`/
+    `_protect_and_track` itself, but consumes the class constants like any
+    sibling.
+    """
+
+    if TYPE_CHECKING:
+        # Supplied by PersistenceOps (assigned in its __init__, or defined
+        # as real methods on it - these annotations are overridden by those
+        # real definitions, never the other way round).
+        state: dict[str, Any]
+        state_file: Any
+
+        def _save_state(self, state_data: dict[str, Any] | None = None) -> None: ...
+
+        def _protect_and_track(self, value: str) -> str: ...
+
+        # Supplied by SettingsManager's own class body. Closed vocabularies
+        # and lookup tables the mixins validate against.
+        NOTIFICATION_TYPES: tuple[str, ...]
+        REASONING_LEVELS: tuple[str, ...]
+        LOG_LEVELS: tuple[str, ...]
+        THEMES: tuple[str, ...]
+        SECRET_KEYS: tuple[str, ...]
+        OLLAMA_MODEL_TASKS: tuple[Any, ...]
+        LEGACY_PRODUCT_MODEL_IDS: set[str]
+        CURRENT_SCHEMA_VERSION: int

--- a/settings_store/cloud_provider.py
+++ b/settings_store/cloud_provider.py
@@ -24,11 +24,13 @@ the class wrapper is new.
 
 from __future__ import annotations
 
+from settings_store._composed import SettingsManagerParts
+
 import graphlink_secrets
 from graphlink_model_catalog import normalize_model_id
 
 
-class CloudProviderSettingsOps:
+class CloudProviderSettingsOps(SettingsManagerParts):
 
     def get_anthropic_reasoning_level(self):
         return self.state.get("anthropic_reasoning_level", "off")

--- a/settings_store/general.py
+++ b/settings_store/general.py
@@ -15,10 +15,12 @@ the class wrapper is new.
 
 from __future__ import annotations
 
+from settings_store._composed import SettingsManagerParts
+
 from datetime import datetime, timezone
 
 
-class GeneralSettingsOps:
+class GeneralSettingsOps(SettingsManagerParts):
 
     def get_show_token_counter(self):
         # R8a: off by default - the overlay is opt-in now, not opt-out.

--- a/settings_store/harness.py
+++ b/settings_store/harness.py
@@ -12,8 +12,10 @@ the class wrapper is new.
 
 from __future__ import annotations
 
+from settings_store._composed import SettingsManagerParts
 
-class HarnessSettingsOps:
+
+class HarnessSettingsOps(SettingsManagerParts):
 
     def get_harness_trusted_dirs(self) -> list:
         """PLAN-2026-08-24 H4: directories the user has explicitly granted

--- a/settings_store/llama_cpp.py
+++ b/settings_store/llama_cpp.py
@@ -16,13 +16,15 @@ the class wrapper is new.
 
 from __future__ import annotations
 
+from settings_store._composed import SettingsManagerParts
+
 
 def _is_llama_cpp_gguf_path(path_value) -> bool:
     normalized = str(path_value or "").strip()
     return bool(normalized) and normalized.lower().endswith(".gguf")
 
 
-class LlamaCppSettingsOps:
+class LlamaCppSettingsOps(SettingsManagerParts):
 
     def get_llama_cpp_chat_model_path(self):
         return str(self.state.get("llama_cpp_chat_model_path", "")).strip()

--- a/settings_store/mcp.py
+++ b/settings_store/mcp.py
@@ -17,6 +17,8 @@ the class wrapper is new.
 
 from __future__ import annotations
 
+from settings_store._composed import SettingsManagerParts
+
 import uuid
 
 import graphlink_secrets
@@ -36,7 +38,7 @@ def _normalize_mcp_env(raw):
     }
 
 
-class McpSettingsOps:
+class McpSettingsOps(SettingsManagerParts):
 
     def get_mcp_servers(self) -> list:
         """ADR-007 stage 7.5: configured MCP servers - the persisted

--- a/settings_store/ollama.py
+++ b/settings_store/ollama.py
@@ -15,6 +15,8 @@ the class wrapper is new.
 
 from __future__ import annotations
 
+from settings_store._composed import SettingsManagerParts
+
 from graphlink_model_catalog import (
     AUTO_MODEL,
     INHERIT_MODEL,
@@ -24,7 +26,7 @@ from graphlink_model_catalog import (
 )
 
 
-class OllamaSettingsOps:
+class OllamaSettingsOps(SettingsManagerParts):
 
     def get_ollama_model_assignments(self):
         assignments = self.state.get("ollama_model_assignments", {})

--- a/settings_store/persistence.py
+++ b/settings_store/persistence.py
@@ -16,6 +16,8 @@ the class wrapper and imports are new.
 
 from __future__ import annotations
 
+from settings_store._composed import SettingsManagerParts
+
 import json
 import logging
 import os
@@ -35,7 +37,7 @@ from graphlink_model_catalog import (
 logger = logging.getLogger(__name__)
 
 
-class PersistenceOps:
+class PersistenceOps(SettingsManagerParts):
 
     def __init__(self, state_file: Path | str | None = None):
         self.state_file = Path(state_file) if state_file is not None else Path.home() / '.graphlink' / 'session.dat'

--- a/settings_store/plugin_grants.py
+++ b/settings_store/plugin_grants.py
@@ -12,8 +12,10 @@ the class wrapper is new.
 
 from __future__ import annotations
 
+from settings_store._composed import SettingsManagerParts
 
-class PluginGrantsOps:
+
+class PluginGrantsOps(SettingsManagerParts):
 
     def get_plugin_grants(self) -> dict:
         """ADR-014 stage 14.4: install-time consent grants for discovered

--- a/settings_store/pricing.py
+++ b/settings_store/pricing.py
@@ -12,8 +12,10 @@ the class wrapper is new.
 
 from __future__ import annotations
 
+from settings_store._composed import SettingsManagerParts
 
-class PricingSettingsOps:
+
+class PricingSettingsOps(SettingsManagerParts):
 
     def get_pricing_overrides(self) -> dict:
         """ADR-016 stage 16.2: user-editable local pricing table, keyed by

--- a/settings_store/recipes.py
+++ b/settings_store/recipes.py
@@ -13,8 +13,10 @@ the class wrapper is new.
 
 from __future__ import annotations
 
+from settings_store._composed import SettingsManagerParts
 
-class RecipesOps:
+
+class RecipesOps(SettingsManagerParts):
 
     @staticmethod
     def _normalize_recipe(entry) -> "dict | None":

--- a/tests/test_settings_mixin_contract.py
+++ b/tests/test_settings_mixin_contract.py
@@ -1,0 +1,71 @@
+"""Guard the guard: settings_store/_composed.py must stay type-only.
+
+SettingsManagerParts exists so a type checker can see the contract between
+the ten settings_store mixins and the SettingsManager that composes them.
+It sits LAST in that class's MRO, immediately before object, which makes it
+the perfect place for an accident: anything defined there outside the
+`if TYPE_CHECKING:` block becomes a real attribute that silently shadows
+nothing today, but would be picked up the moment a sibling mixin stopped
+defining its own - a fallback nobody asked for, in the one class written to
+have no behaviour at all.
+
+Same posture as tests/test_domain_purity.py and test_node_state_migration.py:
+the property is cheap to assert and expensive to notice by eye. This is also
+the reason [tool.mypy].files can include settings_store at all, so it is
+worth keeping honest.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from graphlink_settings_store import SettingsManager
+from settings_store._composed import SettingsManagerParts
+
+# Everything SettingsManagerParts declares, and who really supplies it. Kept
+# explicit rather than derived: the point is to notice when the list changes.
+_DECLARED_INSTANCE_SURFACE = ("state", "state_file", "_save_state", "_protect_and_track")
+_DECLARED_CLASS_CONSTANTS = (
+    "NOTIFICATION_TYPES", "REASONING_LEVELS", "LOG_LEVELS", "THEMES",
+    "SECRET_KEYS", "OLLAMA_MODEL_TASKS", "LEGACY_PRODUCT_MODEL_IDS",
+    "CURRENT_SCHEMA_VERSION",
+)
+
+
+def test_the_declaration_base_has_no_runtime_body():
+    """Nothing but dunders. A method or attribute here would be a real
+    implementation in a class whose entire purpose is to have none."""
+    own = [name for name in vars(SettingsManagerParts) if not name.startswith("__")]
+    assert own == [], f"SettingsManagerParts gained a runtime member: {own}"
+
+
+def test_it_defines_no_initializer():
+    """An __init__ here would land in SettingsManager's MRO after every real
+    mixin and quietly change construction."""
+    assert "__init__" not in vars(SettingsManagerParts)
+
+
+def test_every_declared_name_is_really_provided_by_the_composed_class():
+    """The declaration has to describe reality, or it is just a way to make
+    mypy agree with a lie. A name dropped from SettingsManager (or renamed)
+    must fail here rather than keep type-checking against nothing."""
+    manager = SettingsManager.__new__(SettingsManager)  # no __init__: class surface only
+    for name in _DECLARED_CLASS_CONSTANTS:
+        assert hasattr(type(manager), name), f"SettingsManager no longer defines {name!r}"
+    for name in ("_save_state", "_protect_and_track"):
+        assert callable(getattr(type(manager), name, None)), f"SettingsManager no longer defines {name!r}()"
+
+
+def test_protect_and_track_signature_matches_the_declaration():
+    """The one declared method with a non-trivial signature. A drift here
+    type-checks clean and breaks at runtime."""
+    real = inspect.signature(SettingsManager._protect_and_track)
+    assert list(real.parameters) == ["self", "value"]
+
+
+def test_the_base_sits_last_in_the_mro():
+    """Immediately before object: it must never take precedence over a real
+    mixin's implementation of the same name."""
+    mro = SettingsManager.__mro__
+    assert mro[-1] is object
+    assert mro[-2] is SettingsManagerParts


### PR DESCRIPTION
## Problem

The ten `*Ops` classes in `settings_store/` are mixins, composed exactly once by `SettingsManager`. They use `self.state`, `self._save_state()` and the class constants (`NOTIFICATION_TYPES`, `REASONING_LEVELS`, …) that only exist on the composed whole — correct at runtime, and completely invisible to a checker looking at one mixin in isolation.

That invisibility was not free:

```
mypy settings_store  ->  115 errors in 10 files, ALL attr-defined

  66  "…Ops" has no attribute "state"
  33  "…Ops" has no attribute "_save_state"
   2  "…Ops" has no attribute "_protect_and_track"
  14  class constants (LOG_LEVELS, THEMES, LEGACY_PRODUCT_MODEL_IDS, …)
```

101 of 115 are three names. The package was not badly typed — it was **untypeable**, because nothing declared the contract between a mixin and the class that composes it.

## Change

`settings_store/_composed.py` declares that contract once, and every mixin inherits it.

Everything in it is `TYPE_CHECKING`-only, so **at runtime the class is empty**: no attributes, no methods, no `__init__`. The real implementations still come from `PersistenceOps` and `SettingsManager`'s own class body, exactly as before. The MRO gains one entry, immediately before `object`, where it can never take precedence over a real mixin:

```
SettingsManager -> PersistenceOps -> GeneralSettingsOps -> … -> PricingSettingsOps
                -> SettingsManagerParts -> object

SettingsManagerParts adds attributes at runtime: []
```

`settings_store` now checks clean, so `[tool.mypy].files` gains it — the first widening since that list was written, and the direction its own comment asks for: *"Ratchet this list wider as more modules earn real annotations - never narrower."*

## What this does not fix

This is one half of a larger finding, and the other half is deliberately not attempted here.

The same untyped-mixin shape accounts for **23 classes** across `backend/agent_dispatch/`, `backend/domain/` and here, and is a large part of why the mypy list stayed at four entries while the real error count grew from the 642 its comment records to **1,059** today.

The other half is `SceneNode.state`, typed `NodeState | None` against a field-less marker class — 285 errors on its own. That is **not** a small change: `tests/test_node_state_migration.py` requires every migrated field to be read as `X.state.<field>` and rejects a `state = node.state` alias, which is exactly what a narrowing accessor would need. Making it work means per-call-site narrowing across `graph.py` (287 errors) and `session_save.py` (246), plus reworking that gate. It belongs with the ADR-002 stage 2.5 completion, not here.

## Test plan

- `mypy settings_store`: **115 errors → 0**. Full `python -m mypy` via the project config: clean across 30 source files.
- **5 new gate tests** asserting the declaration stays type-only: no runtime members, no `__init__`, last in the MRO, every declared name really supplied by `SettingsManager`, and `_protect_and_track`'s signature matching. That last pair matters — a declaration that drifts from reality type-checks clean and breaks at runtime.
- Full suite: **3150 passed, 19 skipped**. `ruff` clean, `compileall` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
