### PR TITLE
Actually run the file-permission assertions somewhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,3 +301,49 @@ jobs:
       - name: Run Playwright E2E suite
         working-directory: web_ui
         run: npm run test:e2e
+
+  # A fifth job, and the smallest. python-tests is the only job that runs
+  # pytest and it is pinned to windows-latest for DPAPI, so the 9 tests that
+  # assert POSIX file mode bits - on chats.db, the knowledge store, DB
+  # backups, and session.dat, the secrets-at-rest file - skipped in CI and
+  # ran nowhere else. Nine assertions about the permissions of a file holding
+  # API keys, executing on no machine anyone checked.
+  #
+  # Scoped to the four files that contain them, NOT all of backend/tests:
+  # pytest imports every module it collects, and this file's own comment
+  # above records that ~18 tests elsewhere genuinely assume Windows.
+  # Narrowing collection is what keeps this job about permissions rather
+  # than about porting the suite to Linux. tests/test_posix_permission_
+  # coverage.py ties the file list below to the marked tests, so a tenth
+  # marked test landing in a fifth file fails the build instead of silently
+  # not running here.
+  #
+  # ubuntu-latest, and deliberately cheap: no coverage, no xdist workers
+  # (-n0 for 9 tests), no dev tooling beyond pytest itself.
+  posix-permissions:
+    name: POSIX file permissions (ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      # pytest-xdist is needed even at -n0: [tool.pytest.ini_options].addopts
+      # names -n, so the plugin has to be importable for the run to start.
+      - name: Install pytest
+        run: pip install --quiet pytest==9.1.1 pytest-xdist==3.8.0
+
+      - name: Run the POSIX permission assertions
+        run: >
+          python -m pytest -q -n0 -m posix_permissions
+          backend/tests/test_chat_library.py
+          backend/tests/test_db_backup.py
+          backend/tests/test_knowledge_store.py
+          backend/tests/test_backend_secrets_at_rest.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,8 +337,12 @@ jobs:
 
       # pytest-xdist is needed even at -n0: [tool.pytest.ini_options].addopts
       # names -n, so the plugin has to be importable for the run to start.
+      # hypothesis for the same class of reason - backend/tests/conftest.py
+      # imports it at module scope, so pytest cannot load the conftest (and
+      # therefore collects nothing at all) without it. Versions match the
+      # python-tests job's own pins.
       - name: Install pytest
-        run: pip install --quiet pytest==9.1.1 pytest-xdist==3.8.0
+        run: pip install --quiet pytest==9.1.1 pytest-xdist==3.8.0 hypothesis==6.165.10
 
       - name: Run the POSIX permission assertions
         run: >

--- a/backend/tests/test_backend_secrets_at_rest.py
+++ b/backend/tests/test_backend_secrets_at_rest.py
@@ -461,6 +461,7 @@ class TestSessionFilePermissionsAreRestricted:
 
         assert (state_file, 0o600) in calls
 
+    @pytest.mark.posix_permissions
     def test_posix_permission_bits_are_actually_0600(self, tmp_path):
         if sys.platform == "win32":
             pytest.skip("chmod is a no-op on Windows - see class docstring")
@@ -470,6 +471,7 @@ class TestSessionFilePermissionsAreRestricted:
 
         assert stat.S_IMODE(state_file.stat().st_mode) == 0o600
 
+    @pytest.mark.posix_permissions
     def test_self_heals_a_pre_existing_file_with_looser_permissions(self, tmp_path):
         if sys.platform == "win32":
             pytest.skip("chmod is a no-op on Windows - see class docstring")
@@ -514,6 +516,7 @@ class TestCorruptedStateBackupIsAlsoChmodded:
         backup_path = next(tmp_path.glob("session.dat.corrupted-*"))
         assert (backup_path, 0o600) in calls
 
+    @pytest.mark.posix_permissions
     def test_posix_permission_bits_on_the_backup_are_actually_0600(self, tmp_path):
         if sys.platform == "win32":
             pytest.skip("chmod is a no-op on Windows - see class docstring")

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -116,6 +116,7 @@ class TestChatsDbPermissionsAreRestricted:
 
         assert (db_path, 0o600) in calls
 
+    @pytest.mark.posix_permissions
     def test_posix_permission_bits_are_actually_0600(self, db_path):
         if sys.platform == "win32":
             pytest.skip("chmod is a no-op on Windows - see class docstring")
@@ -124,6 +125,7 @@ class TestChatsDbPermissionsAreRestricted:
 
         assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
 
+    @pytest.mark.posix_permissions
     def test_self_heals_a_pre_existing_db_with_looser_permissions(self, db_path):
         if sys.platform == "win32":
             pytest.skip("chmod is a no-op on Windows - see class docstring")
@@ -214,6 +216,7 @@ class TestChatsDbUsesWalModeForChmoddableSidecars:
         assert (wal_path, 0o600) in calls
         assert (shm_path, 0o600) in calls
 
+    @pytest.mark.posix_permissions
     def test_self_heals_stale_sidecars_left_behind_by_a_crash(self, db_path):
         if sys.platform == "win32":
             pytest.skip("chmod is a no-op on Windows - see class docstring")

--- a/backend/tests/test_db_backup.py
+++ b/backend/tests/test_db_backup.py
@@ -155,6 +155,7 @@ def test_take_backup_is_wal_safe_against_a_live_writer_holding_a_transaction(db_
         writer.close()
 
 
+@pytest.mark.posix_permissions
 def test_take_backup_chmods_the_backup_to_0600(db_path):
     import stat
     import sys
@@ -380,6 +381,7 @@ def test_restore_is_atomic_no_leftover_temp_file_on_success(db_path):
     assert not tmp_path.exists()
 
 
+@pytest.mark.posix_permissions
 def test_restore_chmods_the_restored_file_to_0600(db_path):
     import stat
     import sys

--- a/backend/tests/test_knowledge_store.py
+++ b/backend/tests/test_knowledge_store.py
@@ -46,6 +46,7 @@ class TestConnectionHygiene:
             conn.close()
         assert mode.lower() == "wal"
 
+    @pytest.mark.posix_permissions
     def test_posix_permission_bits_are_actually_0600(self, db_path):
         if os.name == "nt":
             pytest.skip("POSIX permission bits are not meaningful on Windows")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,22 @@ dev = ["pytest", "pytest-cov", "pytest-xdist", "ruff", "mypy", "hypothesis", "mu
 # the perf suite - CI passes -n0 there explicitly, since its timing
 # assertions must not share a loaded machine with 11 sibling workers).
 addopts = "--strict-markers --strict-config -n auto --dist worksteal"
+# --strict-markers means every marker has to be declared here or the run
+# fails, which is the point: this one is load-bearing, not decorative.
+#
+# posix_permissions marks the 9 tests that assert restrictive file mode bits
+# (0600) on chats.db, the knowledge store, DB backups and session.dat - the
+# secrets-at-rest file. All 9 begin with `if sys.platform == "win32":
+# pytest.skip("chmod is a no-op on Windows")`, and python-tests is the ONLY
+# job in ci.yml that runs pytest at all, pinned to windows-latest for DPAPI.
+# So until the posix-permissions job was added they skipped in CI and ran
+# nowhere else: nine assertions about the permissions of a file holding API
+# keys, executing on no machine anyone checked. The marker is what lets that
+# job select exactly them on ubuntu, without dragging in the ~18 other tests
+# in the same files that genuinely require Windows.
+markers = [
+    "posix_permissions: asserts POSIX file mode bits; skipped on Windows, run by the posix-permissions CI job",
+]
 filterwarnings = [
     "error::DeprecationWarning",
     "error::PendingDeprecationWarning",

--- a/tests/test_posix_permission_coverage.py
+++ b/tests/test_posix_permission_coverage.py
@@ -1,0 +1,83 @@
+"""The posix-permissions CI job has to actually cover the marked tests.
+
+That job (.github/workflows/ci.yml) runs `-m posix_permissions` against an
+EXPLICIT list of four files rather than all of backend/tests, because pytest
+imports every module it collects and roughly 18 tests elsewhere in that
+directory genuinely assume Windows. Narrowing collection is what keeps the
+job about file permissions instead of about porting the suite to Linux.
+
+The cost of narrowing is drift: a tenth `@pytest.mark.posix_permissions`
+test landing in a fifth file would be selected by nobody and run nowhere,
+which is the exact condition this job was added to end - and it would look
+green. So the two are tied together here.
+
+Same posture as tests/test_doc_currency.py (assert the document still
+describes the code) and test_undo_classification_gate.py (assert the
+hand-authored table still matches the registered intents): the check is
+cheap, and the failure it prevents is silent.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+MARKER = "posix_permissions"
+
+
+def _files_with_marked_tests() -> set[str]:
+    """Every file under backend/tests holding a @pytest.mark.posix_permissions
+    test, as a repo-relative posix path."""
+    found: set[str] = set()
+    for path in (REPO_ROOT / "backend" / "tests").rglob("test_*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - a broken test file fails elsewhere
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in node.decorator_list:
+                # @pytest.mark.posix_permissions - bare, never called
+                if isinstance(decorator, ast.Attribute) and decorator.attr == MARKER:
+                    found.add(path.relative_to(REPO_ROOT).as_posix())
+    return found
+
+
+def _files_the_job_runs() -> set[str]:
+    """The backend/tests paths named in the posix-permissions job's own step."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    start = text.index("  posix-permissions:")
+    return set(re.findall(r"(backend/tests/test_[a-z0-9_]+\.py)", text[start:]))
+
+
+def test_the_job_runs_every_file_that_has_a_marked_test():
+    marked = _files_with_marked_tests()
+    listed = _files_the_job_runs()
+    missing = sorted(marked - listed)
+    assert not missing, (
+        "these files hold @pytest.mark.posix_permissions tests the posix-permissions "
+        f"CI job does not run: {missing}. Add them to that job's pytest invocation in "
+        ".github/workflows/ci.yml, or the assertions run on no machine at all."
+    )
+
+
+def test_the_job_does_not_list_files_with_nothing_to_run():
+    marked = _files_with_marked_tests()
+    listed = _files_the_job_runs()
+    stale = sorted(listed - marked)
+    assert not stale, (
+        "the posix-permissions CI job runs these files, but none of them holds a "
+        f"@pytest.mark.posix_permissions test any more: {stale}. Drop them from the "
+        "job rather than paying to collect them."
+    )
+
+
+def test_the_marker_is_actually_in_use():
+    """Guards the guard: if the marker were renamed or dropped, both checks
+    above would pass vacuously on two empty sets."""
+    assert len(_files_with_marked_tests()) >= 4
+    assert len(_files_the_job_runs()) >= 4


### PR DESCRIPTION
## Problem

Nine tests assert restrictive POSIX mode bits (`0600`) on `chats.db`, the knowledge store, DB backups, and `session.dat` — the secrets-at-rest file. Every one of them opens with:

```python
if sys.platform == "win32":
    pytest.skip("chmod is a no-op on Windows")
```

`python-tests` is the only job in this workflow that runs pytest, and it is pinned to `windows-latest` for DPAPI. So all nine skipped in CI and ran nowhere else — nine assertions about the permissions of a file holding API keys, executing on no machine anyone had checked. Confirmed by running the four files directly:

```
backend/tests/test_chat_library.py:122,131,222   chmod is a no-op on Windows
backend/tests/test_db_backup.py:164,390          chmod is a no-op on Windows
backend/tests/test_knowledge_store.py:52         POSIX permission bits not meaningful
backend/tests/test_backend_secrets_at_rest.py:467,477,522   chmod is a no-op on Windows

264 passed, 9 skipped
```

## Change

The nine are marked `posix_permissions` (registered in `pyproject.toml`, which `--strict-markers` requires), and a fifth CI job runs exactly them on ubuntu.

That job names **four files** rather than collecting `backend/tests` wholesale. pytest imports every module it collects, and this workflow's own comment records that ~18 tests elsewhere in that directory genuinely assume Windows — `CREATE_NO_WINDOW`, `os.startfile`, and the DPAPI suite that asserts encryption actually happened. Narrowing collection keeps the job about file permissions rather than about porting the suite to Linux.

The cost of narrowing is drift, so the two are tied together. `tests/test_posix_permission_coverage.py` fails if a marked test appears in a file the job does not run, or if the job lists a file with nothing left to run, and asserts both sets are non-empty so it cannot pass vacuously on two empty sets.

The job is deliberately cheap: ubuntu (1x billing), no coverage, no xdist workers, no dev tooling beyond pytest. `pytest-xdist` is still installed because `addopts` names `-n`, so the plugin must be importable even at `-n0`.

## Test plan

- The marker selects exactly 9 tests (3003 deselected), and they still skip correctly on Windows.
- The coverage gate fires on drift — verified by temporarily marking a test in a fifth file, which the gate named and failed on — and is green otherwise.
- Full suite: **3148 passed, 19 skipped**. `ruff` clean. Workflow YAML parses with all five jobs.

The nine assertions themselves have not run on Linux before, so this job's first run is also their first real execution. The production code calls `os.chmod(path, 0o600)` unconditionally (with a logged fallback), and `chmod` is not umask-sensitive, so they are expected to pass — but that expectation is exactly what this job exists to stop being an expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
