### PR TITLE
Narrow node state at the access point, and put mypy on backend/domain

### DIFF
--- a/backend/domain/node_access.py
+++ b/backend/domain/node_access.py
@@ -1,0 +1,81 @@
+"""require_node - fetch a node, check its kind, and narrow its state type.
+
+Every per-kind SceneDocument method opens with the same five lines: look the
+node up, raise if it is missing, raise if it is the wrong kind, then read or
+write `node.state.<kind>_<field>`. Eighteen copies of that preamble existed
+in the two extracted per-kind mixins alone.
+
+The repetition is the smaller half. The larger half is that
+`SceneNode.state` is typed `NodeState | None` against a marker class with no
+fields, so EVERY one of those field accesses is unverifiable - 327 of the
+845 remaining `mypy backend` errors are exactly this, and it is why
+[tool.mypy].files could not widen to backend/domain/.
+
+WHY THIS WORKS, when a `state = node.state` alias does not:
+tests/test_node_state_migration.py requires every migrated field to be read
+as `<anything>.state.<field>` - see its own `_is_via_state`, which checks
+only that the attribute being accessed sits on something whose attribute is
+`state`. It constrains the SHAPE of the access, not how the node was
+obtained. So narrowing the NODE is allowed where aliasing the STATE is not,
+and `node.state.code_review_pr_url` satisfies the gate and the type checker
+at the same time.
+
+_NodeWith exists only for the checker: at runtime require_node returns the
+plain SceneNode it looked up, unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from backend.domain.model import SceneError, SceneNode
+from backend.domain.node_states import NodeState
+
+_S = TypeVar("_S", bound=NodeState)
+
+if TYPE_CHECKING:
+    class _NodeWith(SceneNode, Generic[_S]):
+        """A SceneNode whose `state` is known to be a particular kind's.
+
+        Type-only: never constructed, never imported at runtime.
+        """
+
+        state: _S  # type: ignore[assignment]
+
+
+def require_node(
+    nodes: dict[str, SceneNode], node_id: str, kind: str, state_cls: type[_S],
+) -> _NodeWith[_S]:
+    """The node with `node_id`, guaranteed to exist and to be `kind`.
+
+    Raises SceneError with the same two messages every hand-written copy of
+    this preamble used, so the wire-level error text callers already depend
+    on is unchanged.
+
+    `state_cls` is not checked at runtime - the kind string is the real
+    guarantee, and the per-kind state class is assigned by the one
+    `add_*_node` constructor for that kind. It is here to carry the type
+    through, and to make the call site say which state it expects.
+    """
+    node = nodes.get(node_id)
+    if node is None:
+        raise SceneError(f"unknown node: {node_id}")
+    if node.kind != kind:
+        raise SceneError(f"node is not a {kind} node: {node_id}")
+    return node  # type: ignore[return-value]
+
+
+def optional_node(
+    nodes: dict[str, SceneNode], node_id: str, kind: str, state_cls: type[_S],
+) -> "_NodeWith[_S] | None":
+    """require_node's silent sibling: None instead of a raise.
+
+    The `fail_*_run` methods deliberately do nothing when their node has
+    already been deleted - a run that fails after the user removed its node
+    is not an error worth surfacing. They still need the narrowed state type
+    for the fields they set on the way through.
+    """
+    node = nodes.get(node_id)
+    if node is None or node.kind != kind:
+        return None
+    return node  # type: ignore[return-value]

--- a/backend/domain/nodes_code_review.py
+++ b/backend/domain/nodes_code_review.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from backend.domain._composed import SceneDocumentParts
 from backend.domain.model import SceneError, SceneNode
+from backend.domain.node_access import optional_node, require_node
 from backend.domain.node_states import CodeReviewState
 
 def _bundle_int(value: object) -> int:
@@ -33,7 +34,7 @@ def _bundle_int(value: object) -> int:
     defence, for a bundle that reached here by any other route (a test, a
     future caller, a hand-built payload)."""
     try:
-        return max(0, int(value))  # type: ignore[arg-type]
+        return max(0, int(value))  # type: ignore[call-overload]
     except (TypeError, ValueError):
         return 0
 
@@ -66,11 +67,7 @@ class CodeReviewOps(SceneDocumentParts):
         or pastes the PR link BEFORE ever clicking Fetch, with no other
         action call site to piggyback on (the setGitlinkLocalRoot
         precedent exactly)."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "code_review":
-            raise SceneError(f"node is not a code_review node: {node_id}")
+        node = require_node(self.nodes, node_id, "code_review", CodeReviewState)
         node.state.code_review_pr_url = str(pr_url)
         return node
 
@@ -97,11 +94,7 @@ class CodeReviewOps(SceneDocumentParts):
         UNCONDITIONALLY (the R5.3 post-review FIX 6 precedent) so the
         frontend's lazy-diff guard can never serve a previous fetch's
         text for this one."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "code_review":
-            raise SceneError(f"node is not a code_review node: {node_id}")
+        node = require_node(self.nodes, node_id, "code_review", CodeReviewState)
         pr_number_value = _bundle_int(bundle.get("pr_number"))
         node.state.code_review_pr_url = str(pr_url)
         node.state.code_review_repo = str(bundle.get("repo", ""))
@@ -144,11 +137,7 @@ class CodeReviewOps(SceneDocumentParts):
         EXCLUDED from scene_payload() (see CodeReviewState's own comment) -
         this is the only way the frontend ever gets the full text, via the
         read-only fetchCodeReviewDiffText intent."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "code_review":
-            raise SceneError(f"node is not a code_review node: {node_id}")
+        node = require_node(self.nodes, node_id, "code_review", CodeReviewState)
         return node.state.code_review_diff_text
 
     def start_code_review_run(self, node_id: str) -> SceneNode:
@@ -156,11 +145,7 @@ class CodeReviewOps(SceneDocumentParts):
         prior review visible until the new one lands (stale-while-
         revalidate, the start_gitlink_run precedent - a failed re-run must
         never blank a previously good review)."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "code_review":
-            raise SceneError(f"node is not a code_review node: {node_id}")
+        node = require_node(self.nodes, node_id, "code_review", CodeReviewState)
         node.state.code_review_error = ""
         return node
 
@@ -187,11 +172,7 @@ class CodeReviewOps(SceneDocumentParts):
         review resets dismissals: finding ids are re-minted per review,
         so a dismissal of the old review's f3 must never hide the new
         review's f3."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "code_review":
-            raise SceneError(f"node is not a code_review node: {node_id}")
+        node = require_node(self.nodes, node_id, "code_review", CodeReviewState)
         node.state.code_review_title = str(title)
         node.state.code_review_overview = str(overview)
         node.state.code_review_confidence = str(confidence)
@@ -222,7 +203,7 @@ class CodeReviewOps(SceneDocumentParts):
         (the fail_gitlink_run precedent). Deliberately does NOT clear any
         prior review - a failed re-run must never wipe out a previously
         good one; only the error banner reflects the new failure."""
-        node = self.nodes.get(node_id)
+        node = optional_node(self.nodes, node_id, "code_review", CodeReviewState)
         if node is None:
             return None
         node.state.code_review_error = str(message)
@@ -233,11 +214,7 @@ class CodeReviewOps(SceneDocumentParts):
         affordance). Idempotent: unknown ids and repeats are quiet no-ops,
         never errors - dismissal is UI state, and a double-click must not
         be able to fail a run."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "code_review":
-            raise SceneError(f"node is not a code_review node: {node_id}")
+        node = require_node(self.nodes, node_id, "code_review", CodeReviewState)
         dismissed = str(finding_id)
         known_ids = {
             str(item.get("id")) for item in (
@@ -252,11 +229,7 @@ class CodeReviewOps(SceneDocumentParts):
         """Land one answered follow-up. Capped at the 20 most recent
         entries - the Q&A list is on the wire (unlike the diff text), so
         unbounded growth here would be unbounded wire growth."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "code_review":
-            raise SceneError(f"node is not a code_review node: {node_id}")
+        node = require_node(self.nodes, node_id, "code_review", CodeReviewState)
         node.state.code_review_qa.append({
             "question": str(question),
             "answer": str(answer),

--- a/backend/domain/nodes_gitlink.py
+++ b/backend/domain/nodes_gitlink.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from backend.domain._composed import SceneDocumentParts
 from backend.domain.model import SceneError, SceneNode
+from backend.domain.node_access import optional_node, require_node
 from backend.domain.node_states import GitlinkState
 
 class GitlinkOps(SceneDocumentParts):
@@ -46,11 +47,7 @@ class GitlinkOps(SceneDocumentParts):
         action parameter instead): the user may type/paste a local checkout
         path BEFORE ever clicking Import/Build Context, with no other action
         call site to piggyback on."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "gitlink":
-            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node = require_node(self.nodes, node_id, "gitlink", GitlinkState)
         node.state.gitlink_local_root = str(local_root)
         return node
 
@@ -58,11 +55,7 @@ class GitlinkOps(SceneDocumentParts):
         """Lands a successful loadGitlinkRepoTree result: repo, branch
         (resolved server-side, including any default-branch lookup), and the
         scanned text-file path list."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "gitlink":
-            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node = require_node(self.nodes, node_id, "gitlink", GitlinkState)
         node.state.gitlink_repo = str(repo)
         node.state.gitlink_branch = str(branch)
         node.state.gitlink_repo_file_paths = list(file_paths)
@@ -73,11 +66,7 @@ class GitlinkOps(SceneDocumentParts):
         repo/branch/local_root AND gitlink_imported_root (so a later run
         knows this path came from an import, matching legacy repo_state's
         imported_root concept)."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "gitlink":
-            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node = require_node(self.nodes, node_id, "gitlink", GitlinkState)
         node.state.gitlink_repo = str(repo)
         node.state.gitlink_branch = str(branch)
         node.state.gitlink_local_root = str(local_root)
@@ -110,11 +99,7 @@ class GitlinkOps(SceneDocumentParts):
         produce an IDENTICAL summary string (see that field's own comment on
         SceneNode), which was tricking the frontend's lazy-fetch-once guard
         into skipping a real refetch and showing stale XML."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "gitlink":
-            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node = require_node(self.nodes, node_id, "gitlink", GitlinkState)
         node.state.gitlink_scope_mode = str(scope_mode)
         node.state.gitlink_selected_paths = list(selected_paths)
         node.state.gitlink_context_xml = str(context_xml)
@@ -128,11 +113,7 @@ class GitlinkOps(SceneDocumentParts):
         from scene_payload() (see the field's own comment on SceneNode) - this
         is the only way the frontend ever gets the full text, via the
         read-only fetchGitlinkContext intent."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "gitlink":
-            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node = require_node(self.nodes, node_id, "gitlink", GitlinkState)
         return node.state.gitlink_context_xml
 
     def start_gitlink_run(self, node_id: str, task_prompt: str) -> SceneNode:
@@ -143,11 +124,7 @@ class GitlinkOps(SceneDocumentParts):
         complete_gitlink_run lands a real result, same stale-while-revalidate
         posture web research's own start_web_research_run documents for
         research_result."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
-        if node.kind != "gitlink":
-            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node = require_node(self.nodes, node_id, "gitlink", GitlinkState)
         node.state.gitlink_task_prompt = str(task_prompt)
         node.state.gitlink_error = ""
         return node
@@ -179,9 +156,7 @@ class GitlinkOps(SceneDocumentParts):
         `local_root` is compared as raw trimmed text against
         start_gitlink_apply's own local_root_text - stored stripped here so
         that comparison lines up exactly."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
+        node = require_node(self.nodes, node_id, "gitlink", GitlinkState)
         node.state.gitlink_proposal_markdown = str(proposal_markdown)
         node.state.gitlink_pending_changes = list(pending_changes or [])
         node.state.gitlink_preview_text = str(preview_text)
@@ -204,7 +179,7 @@ class GitlinkOps(SceneDocumentParts):
         change_state - a failed re-run must never wipe out a previously
         staged, still-valid proposal; only the error banner reflects the
         new failure."""
-        node = self.nodes.get(node_id)
+        node = optional_node(self.nodes, node_id, "gitlink", GitlinkState)
         if node is None:
             return None
         node.state.gitlink_error = str(message)
@@ -225,9 +200,7 @@ class GitlinkOps(SceneDocumentParts):
         gitlink_proposal_markdown/gitlink_preview_text are DELIBERATELY left
         untouched - they remain visible as a historical record of what was
         applied."""
-        node = self.nodes.get(node_id)
-        if node is None:
-            raise SceneError(f"unknown node: {node_id}")
+        node = require_node(self.nodes, node_id, "gitlink", GitlinkState)
         node.state.gitlink_change_state = "applied"
         node.state.gitlink_error = ""
         node.state.gitlink_pending_changes = []
@@ -244,7 +217,7 @@ class GitlinkOps(SceneDocumentParts):
         fingerprint-mismatch refusal path, the local_root-mismatch refusal
         path, and the write-failure path identically - all three are "the
         apply did not happen, here is why"."""
-        node = self.nodes.get(node_id)
+        node = optional_node(self.nodes, node_id, "gitlink", GitlinkState)
         if node is None:
             return None
         node.state.gitlink_change_state = "previewed"

--- a/backend/tests/test_review_lens_backend.py
+++ b/backend/tests/test_review_lens_backend.py
@@ -475,3 +475,33 @@ def test_picker_creates_review_lens_node_and_undo_removes_it():
         assert node_id not in document.nodes
 
     asyncio.run(run())
+
+
+# -- wrong-kind guards, now uniform ------------------------------------------
+# require_node/optional_node (backend/domain/node_access.py) gave three gitlink
+# methods and two fail_*_run methods a kind check they did not have. Before,
+# passing a wrong-kind node id reached `node.state.<kind>_<field>` on a state
+# class without that field and raised AttributeError - which the WS layer does
+# not translate, unlike SceneError. These pin the new, uniform behaviour.
+
+
+def test_a_wrong_kind_node_raises_scene_error_not_attribute_error():
+    doc, _ = _doc_with_review()
+    chat = doc.add_chat_node(0, 0, "c", is_user=True)
+    for call in (
+        lambda: doc.store_code_review_diff(chat.id, pr_url="u", bundle=_bundle()),
+        lambda: doc.fetch_code_review_diff_text(chat.id),
+        lambda: doc.append_code_review_qa(chat.id, "q", "a"),
+    ):
+        with pytest.raises(SceneError):
+            call()
+
+
+def test_fail_run_is_a_quiet_no_op_for_a_wrong_kind_node():
+    """fail_*_run is documented as silent when its node has gone. A node that
+    is present but of another kind is the same situation from the run's point
+    of view, and used to raise AttributeError instead."""
+    doc, _ = _doc_with_review()
+    chat = doc.add_chat_node(0, 0, "c", is_user=True)
+    assert doc.fail_code_review_run(chat.id, "boom") is None
+    assert doc.fail_code_review_run("missing", "boom") is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,6 +356,20 @@ files = [
     "backend/events.py",
     "backend/token_counter.py",
     "graphlink_process_env.py",
+    # 2026-09-04, second widening: the first three backend/domain/ entries.
+    #
+    # The blocker was never annotation effort - it was that SceneNode.state is
+    # typed `NodeState | None` against a field-less marker, so every per-kind
+    # field access was unverifiable. backend/domain/node_access.py's
+    # require_node narrows the NODE, which
+    # tests/test_node_state_migration.py permits (it constrains the ACCESS
+    # SHAPE, `<anything>.state.<field>`, not how the node was obtained) where
+    # aliasing the state does not. These three modules check clean because of
+    # it; the rest of backend/domain/ follows as its per-kind groups are
+    # extracted the same way.
+    "backend/domain/node_access.py",
+    "backend/domain/nodes_code_review.py",
+    "backend/domain/nodes_gitlink.py",
     # 2026-09-04: the first widening since this list was written, and the
     # ratchet moving the direction its own comment asks for.
     #


### PR DESCRIPTION
## The audit was wrong to call this blocked

QA item C2 gap 1 — 327 `union-attr` errors from `SceneNode.state` being typed `NodeState | None` against a field-less marker — was written off as impossible, and #397 and #407 both repeated the claim: a typed accessor needs a local alias, and `tests/test_node_state_migration.py` rejects aliases.

Re-reading the gate is what showed that was wrong. Its own `_is_via_state`:

```python
return isinstance(value_node, ast.Attribute) and value_node.attr == "state"
```

It constrains the **access shape** — `<anything>.state.<field>` — and says nothing about how the node was obtained. So narrowing the **node** is permitted where aliasing the **state** is not, and `node.state.code_review_pr_url` satisfies the gate and the type checker at the same time.

## Change

`require_node(nodes, node_id, kind, StateClass)` returns the node with its state type narrowed, performing the two existing `SceneError` raises verbatim. `optional_node` is its silent sibling for the `fail_*_run` methods. Eighteen copies of the same five-line preamble collapse to one call each.

```
mypy backend:                              845 errors  ->  659
nodes_code_review.py + nodes_gitlink.py:    93 errors  ->    0
```

Both modules now check clean, so `[tool.mypy].files` gains its **first three `backend/domain/` entries**. The rest of the package follows as its per-kind groups are extracted the same way (#409).

`_NodeWith` exists only for the checker — at runtime `require_node` returns the plain `SceneNode` it looked up, unchanged.

## Two deliberate behaviour changes

Both narrow a crash into a handled error, and both are pinned by new tests.

Five methods had **no kind check at all**: three gitlink ones that raised only on a missing node, and two `fail_*_run` ones that returned `None` only for a missing node. Passing a wrong-kind node id to any of them reached `node.state.<kind>_<field>` on a state class without that field and raised `AttributeError` — which the WS layer does not translate, unlike `SceneError`.

They now behave like every sibling: raise `SceneError`, or — for `fail_*_run`, whose documented contract is already "silent when the node has gone" — return `None`.

## Test plan

- 2 new tests pinning both changes: a wrong-kind id raises `SceneError` from store/fetch/append, and `fail_*_run` is a quiet no-op for it.
- `tests/test_node_state_migration.py` and `test_domain_purity.py` green — the access shape is unchanged, and `node_access.py` imports nothing the domain layer may not.
- Full suite: **3226 passed, 19 skipped**. `ruff` clean, `mypy` clean across **33** source files (was 30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
